### PR TITLE
Update type for removePullWatch as the callback is optional

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,7 +120,7 @@ declare global {
         removePullWatch: (
           pullPattern: string,
           entityId: string,
-          callback: (before: PullBlock, after: PullBlock) => void
+          callback?: (before: PullBlock, after: PullBlock) => void
         ) => boolean;
         redo: () => void;
         undo: () => void;


### PR DESCRIPTION
As per the official docs the callback is optional and if it is not provided it clears all the watchers from the pull pattern.

https://roamresearch.com/#/app/developer-documentation/page/38i94Seli