### PR TITLE
add graphView types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.82.6",
+  "version": "0.82.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.82.6",
+      "version": "0.82.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.82.6",
+  "version": "0.82.7",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -184,6 +184,18 @@ declare global {
             hideMentions?: boolean;
           }) => null;
         };
+        graphView: {
+          wholeGraph: {
+            addCallback: (props: {
+              label: string;
+              callback: (arg: { "sigma-renderer": unknown }) => void;
+            }) => any;
+            removeCallback: (props: { label: string }) => void;
+            setExplorePages: (pages: string[]) => void;
+            getExplorePages: () => string[];
+            setMode: (mode: "Whole Graph" | "Explore") => void;
+          };
+        };
         mainWindow: {
           focusFirstBlock: () => Promise<void>;
           openBlock: (p: { block: { uid: string } }) => Promise<void>;


### PR DESCRIPTION
used in https://github.com/RoamJS/query-builder/pull/155

from https://roamresearch.com/#/app/developer-documentation/page/tbQbfleXT:
```
roamAlphaAPI.ui.graphView.wholeGraph.addCallback({
  "label": "test",
  "callback": (x) => {
    console.log(x);
  }
})

roamAlphaAPI.ui.graphView.wholeGraph.removeCallback({"label": "test"});

roamAlphaAPI.ui.graphView.wholeGraph.setExplorePages(['a']);
const x = roamAlphaAPI.ui.graphView.wholeGraph.getExplorePages();
console.log(x);

roamAlphaAPI.ui.graphView.wholeGraph.setMode("Whole Graph");
roamAlphaAPI.ui.graphView.wholeGraph.setMode("Explore");
```
Josh Brown:
> the callback just gets a map with {sigma-renderer: ...} , I think that’s enough for your use case, but let me know if you need any other info.

Also for reference, this works:
```
window.roamAlphaAPI.ui.graphView.wholeGraph.addCallback({
  label: "dgraph-colors",
  callback: ({ "sigma-renderer": sig }) => {
    sig.setSetting("nodeReducer", (_, nodeData) => {
      const { label } = nodeData;

      for (const [prefix, color] of prefixColorArray) {
        if (label.startsWith(prefix)) {
          return {
            ...nodeData,
            color,
          };
        }
      }
      
      return nodeData;
    });
  },
});
```