### PR TITLE
AutoCompleteInput: add disabled and maxItemsDisplayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.82.7",
+  "version": "0.82.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.82.7",
+      "version": "0.82.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.82.9",
+  "version": "0.82.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.82.9",
+      "version": "0.82.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.82.9",
+  "version": "0.82.10",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.82.7",
+  "version": "0.82.8",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom";
 import React, { useState, useMemo } from "react";
-import { Button, Checkbox } from "@blueprintjs/core";
+import { Button, Checkbox, NumericInput, Label } from "@blueprintjs/core";
 
 import AutocompleteInput from "./components/AutocompleteInput";
 import FormDialog from "./components/FormDialog";
@@ -66,15 +66,54 @@ const components = [
     callback: () =>
       rootRender(() => {
         const [value, setValue] = useState("");
-        const options = useMemo(() => ["apple", "banana", "orange"], []);
+        const [numResults, setNumResults] = useState(100);
+        const [disabled, setDisabled] = useState(false);
+        const [maxItemsDisplayed, setMaxItemsDisplayed] = useState(0);
+        const options = useMemo(() => {
+          const items = [];
+          for (let i = 0; i < numResults; i++) {
+            items.push(Math.random().toString(36).substring(7));
+          }
+          return items;
+        }, [numResults]);
         return (
           <>
-            <AutocompleteInput
-              value={value}
-              setValue={setValue}
-              options={options}
+            <Label>
+              Number of Results
+              <NumericInput
+                value={numResults}
+                onValueChange={(e) => setNumResults(e)}
+                buttonPosition={"none"}
+              />
+            </Label>
+            <Label>
+              Max Items Displayed (0 for all)
+              <NumericInput
+                value={maxItemsDisplayed}
+                onValueChange={(e) => setMaxItemsDisplayed(e)}
+                buttonPosition={"none"}
+              />
+            </Label>
+            <Label>Chosen value: {value}</Label>
+            <Checkbox
+              checked={disabled}
+              onChange={(e) =>
+                setDisabled((e.target as HTMLInputElement).checked)
+              }
+              label={"Disabled"}
             />
-            <div>Chosen value: {value}</div>
+            <Label>
+              Autocomplete
+              <AutocompleteInput
+                disabled={disabled}
+                value={value}
+                setValue={setValue}
+                options={options}
+                maxItemsDisplayed={
+                  maxItemsDisplayed === 0 ? undefined : maxItemsDisplayed
+                }
+              />
+            </Label>
           </>
         );
       }),

--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -40,6 +40,8 @@ export type AutocompleteInputProps<T = string> = {
     active: boolean;
   }) => React.ReactElement;
   onNewItem?: OnNewItem<T>;
+  disabled?: boolean;
+  maxItemsDisplayed?: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
@@ -58,6 +60,8 @@ const AutocompleteInput = <T extends unknown = string>({
   itemToQuery: _itemToQuery,
   renderItem,
   onNewItem: _onNewItem,
+  disabled = false,
+  maxItemsDisplayed = Infinity,
 }: AutocompleteInputProps<T>): React.ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
   const itemToQuery = useMemo<ItemToQuery<T>>(
@@ -84,8 +88,12 @@ const AutocompleteInput = <T extends unknown = string>({
   );
 
   const items = useMemo(
-    () => (query ? filterOptions(options, query) : options),
-    [query, options, filterOptions]
+    () =>
+      (query ? filterOptions(options, query) : options).slice(
+        0,
+        maxItemsDisplayed
+      ),
+    [query, options, filterOptions, maxItemsDisplayed]
   );
   const menuRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
@@ -192,6 +200,7 @@ const AutocompleteInput = <T extends unknown = string>({
       }
       target={
         <Input
+          disabled={disabled}
           value={query}
           onChange={(e) => {
             setIsTyping(true);

--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -60,7 +60,7 @@ const AutocompleteInput = <T extends unknown = string>({
   itemToQuery: _itemToQuery,
   renderItem,
   onNewItem: _onNewItem,
-  disabled = false,
+  disabled,
   maxItemsDisplayed = Infinity,
 }: AutocompleteInputProps<T>): React.ReactElement => {
   const [isOpen, setIsOpen] = useState(false);


### PR DESCRIPTION
Problem: 
1 - cannot disable `<AutoCompleteInput>`
2 - `<AutoCompleteInput>` renders `<li>` for each result, which can be taxing on large results.

Use case:
1 - disable while returning large UI blocking query
2 - for all `pages` on large graphs and all `blocks` on medium size graphs

https://github.com/RoamJS/roamjs-components/assets/3792666/2dbd04bc-6bd5-4129-9474-cee5ae467d2d

