### PR TITLE
Lift up main observer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.82.11",
+  "version": "0.82.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.82.11",
+      "version": "0.82.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.82.11",
+  "version": "0.82.12",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/dom/createObserver.ts
+++ b/src/dom/createObserver.ts
@@ -5,10 +5,11 @@ const createObserver = (
     mutationList: MutationRecord[],
     observer: MutationObserver
   ) => void
-): MutationObserver =>
-  createDivObserver(
+): MutationObserver => {
+  return createDivObserver(
     mutationCallback,
-    document.getElementsByClassName("roam-body")[0]
+    document.getElementsByClassName("app")[0]
   );
+};
 
 export default createObserver;


### PR DESCRIPTION
Lots of error emails pointing to an observer error down to this line.

My guess is that Roam changed when extensions load such that they are available before the `roam-body` element is rendered. `app` is loaded during the loading state, so I think it's more stable