### PR TITLE
more specific condition on parentRemoved (Closes #27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.83.1",
+      "version": "0.83.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/components/ComponentContainer.tsx
+++ b/src/components/ComponentContainer.tsx
@@ -60,8 +60,7 @@ export const createComponentRender =
             <Fc blockUid={blockUid} />
           </ComponentContainer>,
           b.parentElement,
-          args,
-          blockUid
+          args
         );
       }
     }

--- a/src/components/ComponentContainer.tsx
+++ b/src/components/ComponentContainer.tsx
@@ -60,7 +60,8 @@ export const createComponentRender =
             <Fc blockUid={blockUid} />
           </ComponentContainer>,
           b.parentElement,
-          args
+          args,
+          blockUid
         );
       }
     }

--- a/src/util/renderWithUnmount.ts
+++ b/src/util/renderWithUnmount.ts
@@ -29,7 +29,11 @@ const renderWithUnmount = (
   const unmountObserver = new MutationObserver((ms, observer) => {
     const parentRemoved = ms
       .flatMap((m) => Array.from(m.removedNodes))
-      .some((n) => n === p || n.contains(p));
+      .some((n) => {
+        const el = n as HTMLElement;
+        const roamBodyRemoved = el.classList.contains("roam-body-main");
+        return n === p || (roamBodyRemoved && el.contains(p));
+      });
     if (parentRemoved) {
       unmount(observer);
     }

--- a/src/util/renderWithUnmount.ts
+++ b/src/util/renderWithUnmount.ts
@@ -8,7 +8,8 @@ import removeFromRegistry from "./removeFromRegistry";
 const renderWithUnmount = (
   el: React.ReactElement,
   p: HTMLElement,
-  args?: OnloadArgs
+  args?: OnloadArgs,
+  blockUid?: string
 ): (() => void) => {
   const oldChildren = p.children;
   ReactDOM.render(
@@ -30,9 +31,14 @@ const renderWithUnmount = (
     const parentRemoved = ms
       .flatMap((m) => Array.from(m.removedNodes))
       .some((n) => {
-        const el = n as HTMLElement;
-        const roamBodyRemoved = el.classList.contains("roam-body-main");
-        return n === p || (roamBodyRemoved && el.contains(p));
+        const htmlEl = n as HTMLElement;
+        const roamBodyRemoved = htmlEl.classList.contains("roam-body-main");
+        const blockRemoved = blockUid && htmlEl.id.includes(blockUid);
+        return (
+          n === p ||
+          (roamBodyRemoved && htmlEl.contains(p)) ||
+          (blockRemoved && htmlEl.contains(p))
+        );
       });
     if (parentRemoved) {
       unmount(observer);


### PR DESCRIPTION
This PR is to make `n.contains(p)` more specific to solve #27 

Identified cases:
 - [x] page get navigated away from, eg `<TldrawCanvas>`, 
 - [x] block switches to edit, eg `{{query block}}`, 
 - [ ] ancestor block gets folded

EDIT: found a different solution: don't unmount if `p` is in `addedNodes`