### PR TITLE
use onValueChange instead of onChange

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.83.4",
+  "version": "0.83.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.83.4",
+      "version": "0.83.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.83.4",
+  "version": "0.83.5",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/components/FormDialog.tsx
+++ b/src/components/FormDialog.tsx
@@ -316,7 +316,7 @@ const FormDialog = <T extends Record<string, unknown>>({
                 {meta.label}
                 <NumericInput
                   value={data[name] as string}
-                  onChange={(e) => setValue(e.target.value)}
+                  onValueChange={(v) => setValue(v)}
                   autoFocus={index === 0}
                 />
               </Label>


### PR DESCRIPTION
Reported by Heckler D. via [slack](https://roamresearch.slack.com/archives/CN5MK4D2M/p1724075184781459).

`<NumericInput>` uses `onValueChange` instead of `onChange`
https://blueprintjs.com/docs/versions/3/#core/components/numeric-input
![image](https://github.com/user-attachments/assets/e4906121-6096-4116-af93-784deb21e5f8)

TEST
https://www.loom.com/share/5049db06d5ea46068fad066218d1a96a