### PR TITLE
more robust createTagRegex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.83.6",
+  "version": "0.83.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.83.6",
+      "version": "0.83.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.83.6",
+  "version": "0.83.7",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/util/createTagRegex.ts
+++ b/src/util/createTagRegex.ts
@@ -1,5 +1,7 @@
 const createTagRegex = (title: string): RegExp => {
   const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`#?\\[\\[${escapedTitle}\\]\\]|#${escapedTitle}`);
+  return new RegExp(
+    `(?:#\\[\\[${escapedTitle}\\]\\]|#${escapedTitle}(?!\\w)|\\[\\[${escapedTitle}\\]\\])`
+  );
 };
 export default createTagRegex;

--- a/src/util/createTagRegex.ts
+++ b/src/util/createTagRegex.ts
@@ -1,4 +1,5 @@
-const createTagRegex = (tag: string): RegExp =>
-  new RegExp(`#?\\[\\[${tag}\\]\\]|#${tag}`);
-
+const createTagRegex = (title: string): RegExp => {
+  const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`#?\\[\\[${escapedTitle}\\]\\]|#${escapedTitle}`);
+};
 export default createTagRegex;

--- a/tests/util/createTagRegex.test.ts
+++ b/tests/util/createTagRegex.test.ts
@@ -1,0 +1,60 @@
+import createTagRegex from "../../src/util/createTagRegex";
+import { test, expect } from "@playwright/test";
+
+test("createTagRegex - Matches simple tag", () => {
+  const regex = createTagRegex("test");
+  expect("[[test]]").toMatch(regex);
+  expect("#test").toMatch(regex);
+  expect("#[[test]]").toMatch(regex);
+});
+
+test("createTagRegex - Matches tag with special characters", () => {
+  const regex = createTagRegex("test.*()+?[]");
+  expect("[[test.*()+?[]]]").toMatch(regex);
+  expect("#test.*()+?[]").toMatch(regex);
+});
+
+test("createTagRegex - Complex nested structures", () => {
+  const cases = [
+    "note with [[brackets]]",
+    "[[note]] with * and . and ?",
+    "[[EVD]] - Discourse Graph Evidence - [[@source]]",
+    "[[EVD]] - #tags here",
+  ];
+
+  cases.forEach((content) => {
+    const regex = createTagRegex(content);
+    expect(`[[${content}]]`).toMatch(regex);
+    expect(`#${content}`).toMatch(regex);
+  });
+});
+
+test("createTagRegex - Handles special regex characters", () => {
+  const cases = [
+    "test.note", // dot
+    "v1*", // asterisk
+    "question?", // question mark
+    "tag+", // plus
+    "note[1]", // brackets
+    "path/to/note", // forward slash
+    "note\\path", // backslash
+    "(parentheses)", // parentheses
+    "{curly}", // curly braces
+    "tag|another", // pipe
+    "^start", // caret
+    "end$", // dollar
+  ];
+
+  cases.forEach((tag) => {
+    const regex = createTagRegex(tag);
+    expect(`[[${tag}]]`).toMatch(regex);
+    expect(`#${tag}`).toMatch(regex);
+  });
+});
+
+test("createTagRegex - Does not match partial tags", () => {
+  const regex = createTagRegex("test");
+  expect("testing").not.toMatch(regex);
+  expect("#testing").not.toMatch(regex);
+  expect("[[testing]]").not.toMatch(regex);
+});

--- a/tests/util/createTagRegex.test.ts
+++ b/tests/util/createTagRegex.test.ts
@@ -12,6 +12,7 @@ test("createTagRegex - Matches tag with special characters", () => {
   const regex = createTagRegex("test.*()+?[]");
   expect("[[test.*()+?[]]]").toMatch(regex);
   expect("#test.*()+?[]").toMatch(regex);
+  expect("#[[test.*()+?[]]]").toMatch(regex);
 });
 
 test("createTagRegex - Complex nested structures", () => {
@@ -26,6 +27,7 @@ test("createTagRegex - Complex nested structures", () => {
     const regex = createTagRegex(content);
     expect(`[[${content}]]`).toMatch(regex);
     expect(`#${content}`).toMatch(regex);
+    expect(`#[[${content}]]`).toMatch(regex);
   });
 });
 
@@ -49,6 +51,7 @@ test("createTagRegex - Handles special regex characters", () => {
     const regex = createTagRegex(tag);
     expect(`[[${tag}]]`).toMatch(regex);
     expect(`#${tag}`).toMatch(regex);
+    expect(`#[[${tag}]]`).toMatch(regex);
   });
 });
 


### PR DESCRIPTION
to handle titles like `[[EVD]] - some evidence content - [[@source]]`

![image](https://github.com/user-attachments/assets/9d4a8e3d-f00e-4284-9e76-f63ebf3ab54e)
