### PR TITLE
Upgrade to React 18.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@samepage/scripts": "^0.74.2",
-        "aws-sdk-plus": "^0.5.3",
         "color": "^4.0.1",
         "date-fns": "^2.27.0",
         "edn-data": "^1.0.0",
@@ -3771,86 +3770,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/aws-sdk": {
-      "version": "2.1359.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1359.0.tgz",
-      "integrity": "sha512-uGNIU4czx8P0YITV8uhuLFhmyYvLWsFYINlHJX77/fea4VuTwcCGktYy2OEnrErp3FK9NHQvwXBxZCbY0lcxBg==",
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-sdk-plus": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/aws-sdk-plus/-/aws-sdk-plus-0.5.3.tgz",
-      "integrity": "sha512-C/I1sWXAA5gRh5G4XbqnnVTGfzKimXJVkgBl62rt4SUAjOyakMICvSG/MaS4xzS+6umiVgKH8liWsNmiSueXXA==",
-      "dependencies": {
-        "aws-sdk": "^2.1004.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
-    },
-    "node_modules/aws-sdk-plus/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/aws-sdk-plus/node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "node_modules/aws-sdk-plus/node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/axios": {
@@ -3885,7 +3810,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -3981,16 +3907,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-crc32": {
@@ -5253,14 +5169,6 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5419,6 +5327,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "peer": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -5619,6 +5528,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -5704,6 +5614,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -5905,7 +5816,8 @@
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -6025,6 +5937,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6094,6 +6007,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6179,20 +6093,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -6324,6 +6224,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -6375,7 +6276,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6427,14 +6329,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/jquery": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
@@ -6477,7 +6371,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -6747,6 +6642,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6966,6 +6862,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7778,15 +7675,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -8150,11 +8038,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -8993,15 +8876,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -9018,11 +8892,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -9030,18 +8899,6 @@
       "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -9217,6 +9074,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
       "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -9281,26 +9139,6 @@
       "peer": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {
@@ -12595,71 +12433,8 @@
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-    },
-    "aws-sdk": {
-      "version": "2.1359.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1359.0.tgz",
-      "integrity": "sha512-uGNIU4czx8P0YITV8uhuLFhmyYvLWsFYINlHJX77/fea4VuTwcCGktYy2OEnrErp3FK9NHQvwXBxZCbY0lcxBg==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
-        }
-      }
-    },
-    "aws-sdk-plus": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/aws-sdk-plus/-/aws-sdk-plus-0.5.3.tgz",
-      "integrity": "sha512-C/I1sWXAA5gRh5G4XbqnnVTGfzKimXJVkgBl62rt4SUAjOyakMICvSG/MaS4xzS+6umiVgKH8liWsNmiSueXXA==",
-      "requires": {
-        "aws-sdk": "^2.1004.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      },
-      "dependencies": {
-        "react": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-dom": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "scheduler": "^0.20.2"
-          }
-        },
-        "scheduler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "peer": true
     },
     "axios": {
       "version": "0.27.2",
@@ -12679,7 +12454,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "peer": true
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -12751,16 +12527,6 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "buffer-crc32": {
@@ -13725,11 +13491,6 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -13843,6 +13604,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "peer": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -13996,6 +13758,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "peer": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -14054,6 +13817,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "peer": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -14204,7 +13968,8 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "peer": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -14300,6 +14065,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -14347,7 +14113,8 @@
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "peer": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -14397,14 +14164,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "peer": true
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -14492,6 +14251,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "peer": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -14528,7 +14288,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "peer": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -14568,11 +14329,6 @@
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
       "peer": true
     },
-    "jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
     "jquery": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
@@ -14609,7 +14365,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -14838,6 +14595,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -15007,7 +14765,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true
     },
     "object-hash": {
       "version": "3.0.0",
@@ -15564,11 +15323,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -15845,11 +15599,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "saxes": {
       "version": "6.0.0",
@@ -16483,22 +16232,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
-    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -16521,18 +16254,6 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peer": true,
       "requires": {}
-    },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -16673,6 +16394,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
       "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "peer": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -16717,20 +16439,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "peer": true
-    },
-    "xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "@types/jsdom": "^20.0.1",
         "@types/marked": "^4.0.3",
         "@types/nanoid": "2.0.0",
-        "@types/react": "17.0.39",
-        "@types/react-dom": "17.0.13",
+        "@types/react": "18.2.0",
+        "@types/react-dom": "18.2.0",
         "@types/use-sync-external-store": "^0.0.3",
         "chrono-node": "2.3.0",
         "crypto-js": "3.1.9-1",
@@ -65,8 +65,8 @@
         "marked": "4.0.16",
         "marked-react": "1.1.2",
         "nanoid": "2.0.4",
-        "react": "17.0.2",
-        "react-dom": "17.0.2",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
         "tslib": "2.2.0",
         "use-sync-external-store": "^1.2.0"
       }
@@ -3204,9 +3204,10 @@
       "peer": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -3215,9 +3216,10 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
-      "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/react": "*"
@@ -3804,6 +3806,43 @@
         "aws-sdk": "^2.1004.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
+      }
+    },
+    "node_modules/aws-sdk-plus/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-sdk-plus/node_modules/react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/aws-sdk-plus/node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/aws-sdk/node_modules/uuid": {
@@ -7774,12 +7813,13 @@
       ]
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -7798,16 +7838,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -8128,12 +8169,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/secure-compare": {
@@ -12142,9 +12184,9 @@
       "peer": true
     },
     "@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
       "peer": true,
       "requires": {
         "@types/prop-types": "*",
@@ -12153,9 +12195,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
-      "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "peer": true,
       "requires": {
         "@types/react": "*"
@@ -12587,6 +12629,36 @@
         "aws-sdk": "^2.1004.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
+      },
+      "dependencies": {
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-dom": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
+          }
+        },
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "axios": {
@@ -15509,12 +15581,12 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-day-picker": {
@@ -15527,13 +15599,13 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-is": {
@@ -15789,12 +15861,12 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "secure-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.86.0-alpha.2",
+  "version": "0.86.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.86.0-alpha.2",
+      "version": "0.86.0-alpha.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.85.1",
+  "version": "0.86.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.85.1",
+      "version": "0.86.0-alpha.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/refractor": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
         "@typescript-eslint/parser": "^5.27.1",
+        "dotenv": "16.3.1",
         "eslint": "^8.4.0",
         "http-server": "^14.1.1",
         "prettier": "^2.3.1",
@@ -4688,7 +4689,6 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13125,8 +13125,7 @@
     "dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "peer": true
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "edn-data": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@types/jsdom": "^20.0.1",
     "@types/marked": "^4.0.3",
     "@types/nanoid": "2.0.0",
-    "@types/react": "17.0.39",
-    "@types/react-dom": "17.0.13",
+    "@types/react": "18.2.0",
+    "@types/react-dom": "18.2.0",
     "@types/use-sync-external-store": "^0.0.3",
     "chrono-node": "2.3.0",
     "crypto-js": "3.1.9-1",
@@ -40,8 +40,8 @@
     "marked": "4.0.16",
     "marked-react": "1.1.2",
     "nanoid": "2.0.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "tslib": "2.2.0",
     "use-sync-external-store": "^1.2.0"
   },
@@ -78,9 +78,17 @@
     "roamjs": "./scripts/index.js"
   },
   "overrides": {
-    "@testing-library/react": {
-      "react": "17.0.2",
-      "react-dom": "17.0.2"
+    "@blueprintjs/core": {
+      "react": "18.2.0",
+      "react-dom": "18.2.0"
+    },
+    "@blueprintjs/datetime": {
+      "react": "18.2.0",
+      "react-dom": "18.2.0"
+    },
+    "@blueprintjs/select": {
+      "react": "18.2.0",
+      "react-dom": "18.2.0"
     }
   },
   "samepage": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "@samepage/scripts": "^0.74.2",
-    "aws-sdk-plus": "^0.5.3",
     "color": "^4.0.1",
     "date-fns": "^2.27.0",
     "edn-data": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.86.0-alpha.2",
+  "version": "0.86.0-alpha.3",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "http-server": "^14.1.1",
     "prettier": "^2.3.1",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-react-hooks": "^2.2.2"
+    "tslint-react-hooks": "^2.2.2",
+    "dotenv": "16.3.1"
   },
   "engines": {
     "npm": ">=7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.85.1",
+  "version": "0.86.0-alpha.2",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/patches/@blueprintjs+core+3.50.4.patch
+++ b/patches/@blueprintjs+core+3.50.4.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts b/node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts
+index 09b06be..f74f6a3 100644
+--- a/node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts
++++ b/node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts
+@@ -5,6 +5,7 @@ import { IOverlayLifecycleProps } from "../overlay/overlay";
+ export declare type AlertProps = IAlertProps;
+ /** @deprecated use AlertProps */
+ export interface IAlertProps extends IOverlayLifecycleProps, Props {
++    children?: React.ReactNode;
+     /**
+      * Whether pressing <kbd>escape</kbd> when focused on the Alert should cancel the alert.
+      * If this prop is enabled, then either `onCancel` or `onClose` must also be defined.
+diff --git a/node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts b/node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts
+index e90ee31..3e4f4ef 100644
+--- a/node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts
++++ b/node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts
+@@ -6,6 +6,7 @@ import { IBackdropProps, OverlayableProps } from "../overlay/overlay";
+ export declare type DialogProps = IDialogProps;
+ /** @deprecated use DialogProps */
+ export interface IDialogProps extends OverlayableProps, IBackdropProps, Props {
++    children?: React.ReactNode;
+     /**
+      * Toggles the visibility of the overlay and its children.
+      * This prop is required because the component is controlled.
+diff --git a/node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts b/node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts
+index 2ca5fe5..870a32e 100644
+--- a/node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts
++++ b/node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts
+@@ -6,6 +6,7 @@ export declare const Expander: React.FunctionComponent;
+ export declare type TabsProps = ITabsProps;
+ /** @deprecated use TabsProps */
+ export interface ITabsProps extends Props {
++    children?: React.ReactNode;
+     /**
+      * Whether the selected tab indicator should animate its movement.
+      *
+diff --git a/node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts b/node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts
+index 94f4af9..4db48a9 100644
+--- a/node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts
++++ b/node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts
+@@ -6,6 +6,7 @@ import { IPopoverSharedProps } from "../popover/popoverSharedProps";
+ export declare type TooltipProps = ITooltipProps;
+ /** @deprecated use TooltipProps */
+ export interface ITooltipProps extends IPopoverSharedProps, IntentProps {
++    children?: React.ReactNode;
+     /**
+      * The content that will be displayed inside of the tooltip.
+      */

--- a/patches/@blueprintjs+select+3.18.6.patch
+++ b/patches/@blueprintjs+select+3.18.6.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@blueprintjs/select/lib/esm/components/select/select.d.ts b/node_modules/@blueprintjs/select/lib/esm/components/select/select.d.ts
+index f8b9bc6..ee0b6da 100644
+--- a/node_modules/@blueprintjs/select/lib/esm/components/select/select.d.ts
++++ b/node_modules/@blueprintjs/select/lib/esm/components/select/select.d.ts
+@@ -4,6 +4,7 @@ import { IListItemsProps } from "../../common";
+ export declare type SelectProps<T> = ISelectProps<T>;
+ /** @deprecated use SelectProps */
+ export interface ISelectProps<T> extends IListItemsProps<T> {
++    children?: React.ReactNode;
+     /**
+      * Whether the component should take up the full width of its container.
+      * This overrides `popoverProps.fill`. You also have to ensure that the child

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -12,6 +12,7 @@ import runExtension from "./util/runExtension";
 
 import { createBlock } from "./writes";
 import MenuItemSelect from "./components/MenuItemSelect";
+import TimePanel from "./components/ConfigPanels/TimePanel";
 
 // const blockRender = (Component: React.FC) => {
 //   const block = window.roamAlphaAPI.ui.getFocusedBlock();
@@ -214,6 +215,47 @@ const components = [
       }),
     label: "PageInput",
   },
+  {
+    callback: () =>
+      rootRender(() => {
+        const [value] = useState(new Date());
+        const [uid, setUid] = useState<string>("");
+
+        React.useEffect(() => {
+          const createUid = async () => {
+            const currentPageUid =
+              (await window.roamAlphaAPI.ui.mainWindow.getOpenPageOrBlockUid()) ||
+              window.roamAlphaAPI.util.dateToPageUid(new Date());
+
+            if (!currentPageUid) throw new Error("No current page uid");
+            console.log(currentPageUid);
+            const newUid = await createBlock({
+              parentUid: currentPageUid,
+              node: { text: "time-field" },
+            });
+            setUid(newUid);
+          };
+          createUid();
+        }, []);
+
+        if (!uid) return <div>Loading...</div>;
+
+        return (
+          <>
+            <div>Selected time: {value.toLocaleTimeString()}</div>
+            <TimePanel
+              title="time-field"
+              uid={uid}
+              parentUid="test-parent-uid"
+              order={0}
+              description="Select a time"
+              defaultValue={value}
+            />
+          </>
+        );
+      }),
+    label: "TimePanel",
+  },
 ];
 
 export default runExtension(async (args) => {
@@ -229,6 +271,7 @@ export default runExtension(async (args) => {
       FormDialog,
       PageInput,
       renderToast,
+      TimePanel,
     },
     util: {
       renderOverlay,

--- a/src/components/BlockErrorBoundary.tsx
+++ b/src/components/BlockErrorBoundary.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import createBlock from "../writes/createBlock";
 
-type BlockErrorBoundaryProps = { blockUid: string; message: string };
+type BlockErrorBoundaryProps = {
+  blockUid: string;
+  message: string;
+  children: React.ReactNode;
+};
 type BlockErrorBoundaryState = { hasError: boolean };
 
 class BlockErrorBoundary extends React.Component<

--- a/src/components/ComponentContainer.tsx
+++ b/src/components/ComponentContainer.tsx
@@ -8,6 +8,7 @@ import { OnloadArgs } from "../types/native";
 const ComponentContainer: React.FunctionComponent<{
   blockId?: string;
   className?: string;
+  children?: React.ReactNode;
 }> = ({ blockId, className, children }) => {
   const [showIcons, setShowIcons] = useState(false);
   const appear = useCallback(() => setShowIcons(true), [setShowIcons]);

--- a/src/components/ConfigPanels/OauthPanel.tsx
+++ b/src/components/ConfigPanels/OauthPanel.tsx
@@ -27,7 +27,7 @@ const OauthPanel: FieldPanel<OauthField> = ({ uid, parentUid, options }) => {
       : []
   );
   const onCheck = useCallback(
-    (e) => {
+    (e: React.ChangeEvent<HTMLInputElement>) => {
       const checked = (e.target as HTMLInputElement).checked;
       setUseLocal(checked);
       if (checked) {

--- a/src/components/CursorMenu.tsx
+++ b/src/components/CursorMenu.tsx
@@ -147,7 +147,7 @@ const CursorMenu = <T extends Record<string, string>>({
     [filter, initialItems]
   );
   const onSelect = useCallback(
-    (item) => {
+    (item: { text: string; id: string } & T) => {
       if (menuRef.current) {
         onItemSelect(item);
         onClose();

--- a/src/components/MenuItemSelect.tsx
+++ b/src/components/MenuItemSelect.tsx
@@ -1,5 +1,10 @@
 import { Button, ButtonProps, MenuItem } from "@blueprintjs/core";
-import { SelectProps, Select, ICreateNewItem } from "@blueprintjs/select";
+import {
+  SelectProps,
+  Select,
+  ICreateNewItem,
+  isCreateNewItem,
+} from "@blueprintjs/select";
 import React, { ReactText, ButtonHTMLAttributes, ReactNode } from "react";
 
 type ActiveItem<T> = T | ICreateNewItem | null | undefined;
@@ -38,7 +43,7 @@ const MenuItemSelect = <T extends ReactText>(
   const defaultButton = (
     <Button
       text={
-        activeItem ? (
+        activeItem && !isCreateNewItem(activeItem) ? (
           transformItem ? (
             transformItem(activeItem as T)
           ) : (


### PR DESCRIPTION
We can now `rm node_modules` and `rm package-lock.json` then `npm i` without `--legacy-peer-deps`.

**NOTE:** Only the Blueprint Components used in roamjs-components were patched.

`npm ls react`
```bash
roamjs-components@0.86.0-alpha.2 C:\Users\Michael\Desktop\Areas\RoamJS\RoamJS Repos\roamjs-components
+-- @blueprintjs/core@3.50.4 overridden
| +-- react-popper@1.3.11
| | +-- @hypnosphi/create-react-context@0.3.1
| | | `-- react@18.2.0 deduped
| | `-- react@18.2.0 deduped
| +-- react-transition-group@2.9.0
| | `-- react@18.2.0 deduped
| `-- react@18.2.0 deduped
+-- @blueprintjs/datetime@3.23.14 overridden
| +-- react-day-picker@7.4.9
| | `-- react@18.2.0 deduped
| `-- react@18.2.0 deduped
+-- @blueprintjs/select@3.18.6 overridden
| `-- react@18.2.0 deduped
+-- @samepage/scripts@0.74.2
| `-- @samepage/testing@0.74.2
|   `-- @testing-library/react@14.0.0
|     `-- react@18.2.0 deduped
+-- marked-react@1.1.2
| `-- react@18.2.0 deduped
+-- react-dom@18.2.0 overridden
| `-- react@18.2.0 deduped
+-- react@18.2.0
`-- use-sync-external-store@1.2.0
  `-- react@18.2.0 deduped
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "TimePanel" component, accessible via the command palette, that displays and interacts with time-related data.

* **Bug Fixes**
  * Improved MenuItemSelect to prevent displaying "create new item" as the selected label.

* **Refactor**
  * Enhanced type safety by updating component prop types to explicitly accept children where appropriate.
  * Upgraded React and BlueprintJS dependencies to ensure compatibility and improved typing support.

* **Chores**
  * Updated package dependencies, removed unused packages, and adjusted development tools for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->