### PR TITLE
Update roamAlphaAPI types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.85.3",
+  "version": "0.85.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.85.3",
+      "version": "0.85.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.85.3",
+  "version": "0.85.4",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,21 +107,16 @@ declare global {
           update: WriteAction;
           move: WriteAction;
           delete: WriteAction;
-          reorderBlocks: (
-            args: {
-              location: { "parent-uid": string };
-              blocks: string[];
-            }
-          ) => Promise<void>;
+          reorderBlocks: (args: {
+            location: { "parent-uid": string };
+            blocks: string[];
+          }) => Promise<void>;
         };
         fast: {
           q: (query: string, ...params: unknown[]) => unknown[][];
         };
         async: {
-          q: (
-            query: string,
-            ...params: unknown[]
-          ) => Promise<unknown[][]>;
+          q: (query: string, ...params: unknown[]) => Promise<unknown[][]>;
           pull: (
             selector: string,
             id: number | string | [string, string]
@@ -131,10 +126,7 @@ declare global {
             eids: string[][]
           ) => Promise<PullBlock[]>;
           fast: {
-            q: (
-              query: string,
-              ...params: unknown[]
-            ) => Promise<unknown[][]>;
+            q: (query: string, ...params: unknown[]) => Promise<unknown[][]>;
           };
         };
         backend: {
@@ -171,12 +163,17 @@ declare global {
           open: () => Promise<void>;
           close: () => Promise<void>;
           getWindows: () => SidebarWindow[];
-          addWindow: SidebarAction;
+          addWindow: (action: {
+            window: SidebarWindowInput & { order?: number };
+          }) => Promise<void>;
           setWindowOrder: (action: {
             window: SidebarWindowInput & { order: number };
           }) => Promise<void>;
           collapseWindow: SidebarAction;
-          pinWindow: SidebarAction;
+          pinWindow: (action: {
+            window: SidebarWindowInput;
+            "pin-to-top?"?: boolean;
+          }) => Promise<void>;
           expandWindow: SidebarAction;
           removeWindow: SidebarAction;
           unpinWindow: SidebarAction;
@@ -185,6 +182,8 @@ declare global {
           addCommand: (action: {
             label: string;
             callback: () => void;
+            "disable-hotkey"?: boolean;
+            "default-hotkey"?: string | string[];
           }) => Promise<void>;
           removeCommand: (action: { label: string }) => Promise<void>;
         };
@@ -214,20 +213,31 @@ declare global {
           removeCommand: (action: { label: string }) => void;
         };
         filters: {
-          addGlobalFilter: (args: { title: string; type: "includes" | "removes" }) => Promise<void>;
-          removeGlobalFilter: (args: { title: string; type: "includes" | "removes" }) => Promise<void>;
+          addGlobalFilter: (args: {
+            title: string;
+            type: "includes" | "removes";
+          }) => Promise<void>;
+          removeGlobalFilter: (args: {
+            title: string;
+            type: "includes" | "removes";
+          }) => Promise<void>;
           getGlobalFilters: () => { includes: string[]; removes: string[] };
-          getPageFilters: (args: { page: { uid?: string; title?: string } }) => {
+          getPageFilters: (args: {
+            page: { uid?: string; title?: string };
+          }) => {
             includes: string[];
             removes: string[];
           };
-          getPageLinkedRefsFilters: (args: { page: { uid?: string; title?: string } }) => {
+          getPageLinkedRefsFilters: (args: {
+            page: { uid?: string; title?: string };
+          }) => {
             includes: string[];
             removes: string[];
           };
-          getSidebarWindowFilters: (args: {
-            window: { type: string; "block-uid": string };
-          }) => { includes: string[]; removes: string[] };
+          getSidebarWindowFilters: (args: { window: SidebarWindowInput }) => {
+            includes: string[];
+            removes: string[];
+          };
           setPageFilters: (args: {
             page: { uid?: string; title?: string };
             filters: { includes?: string[]; removes?: string[] };
@@ -237,7 +247,7 @@ declare global {
             filters: { includes?: string[]; removes?: string[] };
           }) => Promise<void>;
           setSidebarWindowFilters: (args: {
-            window: { type: string; "block-uid": string };
+            window: SidebarWindowInput;
             filters: { includes?: string[]; removes?: string[] };
           }) => Promise<void>;
         };
@@ -249,21 +259,20 @@ declare global {
           renderBlock: (args: {
             uid: string;
             el: HTMLElement;
-            zoomPath?: boolean;
-            open?: boolean;
+            "zoom-path?"?: boolean;
+            // "open?"?: boolean; Not available yet in the API
           }) => null;
           renderPage: (args: {
             uid: string;
             el: HTMLElement;
-            hideMentions?: boolean;
-            open?: boolean;
+            "hide-mentions?"?: boolean;
           }) => null;
           renderSearch: (args: {
             "search-query-str": string;
             el: HTMLElement;
-            closed?: boolean;
-            "group-by-page"?: boolean;
-            "hide-paths"?: boolean;
+            "closed?"?: boolean;
+            "group-by-page?"?: boolean;
+            "hide-paths?"?: boolean;
             "config-changed-callback"?: (config: unknown) => void;
           }) => null;
           renderString: (args: { string: string; el: HTMLElement }) => null;
@@ -319,7 +328,10 @@ declare global {
         isEncrypted: boolean;
       };
       file: {
-        upload: (args: { file: File; toast?: { hide: boolean } }) => Promise<string>;
+        upload: (args: {
+          file: File;
+          toast?: { hide: boolean };
+        }) => Promise<string>;
         get: (args: { url: string }) => Promise<File>;
         delete: (args: { url: string }) => Promise<void>;
       };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,8 +107,37 @@ declare global {
           update: WriteAction;
           move: WriteAction;
           delete: WriteAction;
+          reorderBlocks: (
+            args: {
+              location: { "parent-uid": string };
+              blocks: string[];
+            }
+          ) => Promise<void>;
         };
         fast: {
+          q: (query: string, ...params: unknown[]) => unknown[][];
+        };
+        async: {
+          q: (
+            query: string,
+            ...params: unknown[]
+          ) => Promise<unknown[][]>;
+          pull: (
+            selector: string,
+            id: number | string | [string, string]
+          ) => Promise<PullBlock>;
+          pull_many: (
+            pattern: string,
+            eids: string[][]
+          ) => Promise<PullBlock[]>;
+          fast: {
+            q: (
+              query: string,
+              ...params: unknown[]
+            ) => Promise<unknown[][]>;
+          };
+        };
+        backend: {
           q: (query: string, ...params: unknown[]) => unknown[][];
         };
         page: {
@@ -173,6 +202,45 @@ declare global {
           }) => void;
           removeCommand: (action: { label: string }) => void;
         };
+        individualMultiselect: {
+          getSelectedUids: () => string[];
+        };
+        msContextMenu: {
+          addCommand: (action: {
+            label: string;
+            callback: () => void;
+            "display-conditional"?: () => boolean;
+          }) => void;
+          removeCommand: (action: { label: string }) => void;
+        };
+        filters: {
+          addGlobalFilter: (args: { title: string; type: "includes" | "removes" }) => Promise<void>;
+          removeGlobalFilter: (args: { title: string; type: "includes" | "removes" }) => Promise<void>;
+          getGlobalFilters: () => { includes: string[]; removes: string[] };
+          getPageFilters: (args: { page: { uid?: string; title?: string } }) => {
+            includes: string[];
+            removes: string[];
+          };
+          getPageLinkedRefsFilters: (args: { page: { uid?: string; title?: string } }) => {
+            includes: string[];
+            removes: string[];
+          };
+          getSidebarWindowFilters: (args: {
+            window: { type: string; "block-uid": string };
+          }) => { includes: string[]; removes: string[] };
+          setPageFilters: (args: {
+            page: { uid?: string; title?: string };
+            filters: { includes?: string[]; removes?: string[] };
+          }) => Promise<void>;
+          setPageLinkedRefsFilters: (args: {
+            page: { uid?: string; title?: string };
+            filters: { includes?: string[]; removes?: string[] };
+          }) => Promise<void>;
+          setSidebarWindowFilters: (args: {
+            window: { type: string; "block-uid": string };
+            filters: { includes?: string[]; removes?: string[] };
+          }) => Promise<void>;
+        };
         getFocusedBlock: () => null | {
           "window-id": string;
           "block-uid": string;
@@ -182,14 +250,36 @@ declare global {
             uid: string;
             el: HTMLElement;
             zoomPath?: boolean;
+            open?: boolean;
           }) => null;
           renderPage: (args: {
             uid: string;
             el: HTMLElement;
             hideMentions?: boolean;
+            open?: boolean;
           }) => null;
+          renderSearch: (args: {
+            "search-query-str": string;
+            el: HTMLElement;
+            closed?: boolean;
+            "group-by-page"?: boolean;
+            "hide-paths"?: boolean;
+            "config-changed-callback"?: (config: unknown) => void;
+          }) => null;
+          renderString: (args: { string: string; el: HTMLElement }) => null;
+          unmountNode: (args: { el: HTMLElement }) => void;
         };
         graphView: {
+          addCallback: (props: {
+            label: string;
+            callback: (context: {
+              cytoscape: unknown;
+              elements: unknown[];
+              type: "page" | "all-pages";
+            }) => void;
+            type?: "page" | "all-pages";
+          }) => Promise<void>;
+          removeCallback: (props: { label: string }) => Promise<void>;
           wholeGraph: {
             addCallback: (props: {
               label: string;
@@ -227,6 +317,17 @@ declare global {
         name: string;
         type: "hosted" | "offline";
         isEncrypted: boolean;
+      };
+      file: {
+        upload: (args: { file: File; toast?: { hide: boolean } }) => Promise<string>;
+        get: (args: { url: string }) => Promise<File>;
+        delete: (args: { url: string }) => Promise<void>;
+      };
+      user: {
+        uid: () => string | null;
+      };
+      constants: {
+        corsAnywhereProxyUrl: string;
       };
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,7 +141,7 @@ declare global {
           selector: string,
           id: number | string | [string, string]
         ) => PullBlock;
-        pull_many: (pattern: string, eid: string[][]) => PullBlock[];
+        pull_many: (pattern: string, eids: string[][]) => PullBlock[];
         q: (query: string, ...params: unknown[]) => unknown[][];
         removePullWatch: (
           pullPattern: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -163,12 +163,8 @@ declare global {
           open: () => Promise<void>;
           close: () => Promise<void>;
           getWindows: () => SidebarWindow[];
-          addWindow: (action: {
-            window: SidebarWindowInput & { order?: number };
-          }) => Promise<void>;
-          setWindowOrder: (action: {
-            window: SidebarWindowInput & { order: number };
-          }) => Promise<void>;
+          addWindow: SidebarAction;
+          setWindowOrder: SidebarAction;
           collapseWindow: SidebarAction;
           pinWindow: (action: {
             window: SidebarWindowInput;
@@ -275,7 +271,7 @@ declare global {
             "hide-paths?"?: boolean;
             "config-changed-callback"?: (config: unknown) => void;
           }) => null;
-          renderString: (args: { string: string; el: HTMLElement }) => null;
+          // renderString: (args: { string: string; el: HTMLElement }) => null; Not available yet in the API
           unmountNode: (args: { el: HTMLElement }) => void;
         };
         graphView: {

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -371,14 +371,13 @@ type SidebarWindowType =
   | SidebarBlockWindow
   | SidebarMentionsWindow
   | SidebarGraphWindow
-  | SidebarOutlineWindow;
+  | SidebarOutlineWindow
+  | SidebarSearchQueryWindow;
 
 export type SidebarWindowInput = {
-  type: SidebarWindowType["type"] | "search-query";
-} & (
-  | { type: "block" | "outline" | "mentions" | "graph"; "block-uid": string }
-  | { type: "search-query"; "search-query-str": string }
-);
+  type: SidebarWindowType["type"];
+  order?: number;
+};
 
 type SidebarBlockWindow = {
   type: "block";
@@ -399,6 +398,11 @@ type SidebarGraphWindow = {
   type: "graph";
   // "page-uid": string; Currently not working despite documentation
   "block-uid": string;
+};
+
+type SidebarSearchQueryWindow = {
+  type: "search-query";
+  "search-query-uid": string;
 };
 
 export type SidebarAction = (action: {

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -374,9 +374,11 @@ type SidebarWindowType =
   | SidebarOutlineWindow;
 
 export type SidebarWindowInput = {
-  "block-uid": string;
-  type: SidebarWindowType["type"];
-};
+  type: SidebarWindowType["type"] | "search-query";
+} & (
+  | { type: "block" | "outline" | "mentions" | "graph"; "block-uid": string }
+  | { type: "search-query"; "search-query-str": string }
+);
 
 type SidebarBlockWindow = {
   type: "block";


### PR DESCRIPTION
## Summary
- extend roamAlphaAPI types to cover new API docs

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6885ceea91dc83269d5479448ed2df42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Multi-select actions in block context menus, block reordering, file upload/get/delete, user UID and proxy constant exposure, async/backend data query paths, new graph view callbacks, and new render/unmount UI hooks.

- Improvements
  - Global/page/linked/sidebar filter management, richer search UI (query strings, grouping, hide paths, config callbacks), command palette hotkey options, and render options like hide-mentions/zoom-path.

- Chores
  - Version bumped to 0.85.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->