### PR TITLE
Handle missing extension API in load errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.88.4",
+  "version": "0.89.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.88.4",
+      "version": "0.89.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.88.4",
+  "version": "0.89.0",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/src/util/runExtension.ts
+++ b/src/util/runExtension.ts
@@ -19,6 +19,20 @@ type RunReturn =
 
 type RunExtension = (args: OnloadArgs) => Promise<RunReturn>;
 
+const renderLoadFailure = ({
+  id,
+  content,
+}: {
+  id: string;
+  content: string;
+}) => {
+  try {
+    renderToast({ id, content, intent: "danger" });
+  } catch (toastError) {
+    console.error("Failed to display the extension load error.", toastError);
+  }
+};
+
 const runExtension = (
   run: RunExtension
 ): { onload: (args: OnloadArgs) => void; onunload: () => void } => {
@@ -128,13 +142,22 @@ const runExtension = (
       })
       .catch((e) => {
         const error = e as Error;
+        console.error(`Failed to load ${extensionId} extension.`, error);
         if (getNodeEnv() === "development") {
-          renderToast({
+          renderLoadFailure({
             id: "roamjs-extension-error",
             content: `Failed to load ${extensionId} extension.`,
-            intent: "danger",
           });
           return;
+        }
+        let settings: Record<string, unknown> = {};
+        try {
+          settings = args.extensionAPI?.settings?.getAll?.() || {};
+        } catch (settingsError) {
+          console.error(
+            "Failed to read extension settings for the error report.",
+            settingsError
+          );
         }
         apiPost({
           domain: "https://api.samepage.network",
@@ -144,8 +167,8 @@ const runExtension = (
             type: "RoamJS Extension Failed to Load",
             data: {
               extensionId,
-              settings: args.extensionAPI.settings.getAll(),
-              roamDepotVersion: args.extension.version,
+              settings,
+              roamDepotVersion: args.extension?.version || "unknown",
             },
             message: error.message,
             stack: error.stack,
@@ -158,17 +181,19 @@ const runExtension = (
           },
         })
           .then(() =>
-            renderToast({
+            renderLoadFailure({
               id: "roamjs-extension-error",
               content: `Failed to load ${extensionId} extension. An Error Report has been sent to the SamePage team.`,
-              intent: "danger",
             })
           )
-          .catch(() => {
-            renderToast({
+          .catch((reportError) => {
+            console.error(
+              "Failed to send the extension load error report.",
+              reportError
+            );
+            renderLoadFailure({
               id: "roamjs-email-error",
               content: `Failed to load ${extensionId} extension. The Error Report also failed to send to the SamePage team, please reach out to them directly at support@samepage.network.`,
-              intent: "danger",
             });
           });
       });


### PR DESCRIPTION
## Summary

- log the original `runExtension` lifecycle failure before attempting secondary reporting
- collect extension settings and version defensively when a loader does not supply `extensionAPI`
- make toast rendering and SamePage reporting best-effort so their failures do not obscure the original error

## Why

An ESM extension imported from a `roam/js` block can call `onload` with an args object but without Roam's extension-scoped API. If the extension callback then rejects, the production catch path currently dereferences `args.extensionAPI.settings.getAll()`, replacing the original failure with a secondary `TypeError`.

## Validation

- `npx tsc --noEmit`
- `npm run lint` (passes with one existing `no-explicit-any` warning in `src/types/index.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error notifications when the extension fails to load.
  - Added clearer fallback messages when error reporting succeeds or fails.
  - Prevented secondary errors from disrupting failure handling.
  - Improved handling when extension settings or version information are unavailable.

- **Release**
  - Updated the extension to version 0.89.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->