### PR TITLE
Update Roam API types from current docs

### DIFF
--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit
+
+      - name: Check documented API types
+        run: npm run test:types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.91.0
 
 - Updated the Roam Alpha API and extension API types to match the latest developer documentation, including search, markdown import, comments, context menus, custom views, AI tools, and current sidebar window identifiers.
+- Allowed computed boolean values for query grouping and block zoom paths when no dependent sort or start-UID option is supplied.
 
 ## 0.90.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Updated the Roam Alpha API and extension API types to match the latest developer documentation, including search, markdown import, comments, context menus, custom views, AI tools, and current sidebar window identifiers.
 - Allowed computed boolean values for query grouping and block zoom paths when no dependent sort or start-UID option is supplied.
+- Corrected file download types for optional formats and exposed block/page deletion results.
+- Preserved custom page properties and synchronous AI-attributed writes that return a promise, and added custom callout registration types.
 
 ## 0.90.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.91.0
+
+- Updated the Roam Alpha API and extension API types to match the latest developer documentation, including search, markdown import, comments, context menus, custom views, AI tools, and current sidebar window identifiers.
+
 ## 0.90.0
 
 - Preserve Roam's built-in React 18 external-store hook when extensions initialize.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roamjs-components",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roamjs-components",
-      "version": "0.90.0",
+      "version": "0.91.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamjs-components",
   "description": "Expansive toolset, utilities, & components for developing RoamJS extensions.",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --write \"src/**/*.tsx\"",
     "lint": "eslint . --ext .ts,.tsx",
     "build": "tsc",
+    "test:types": "tsc --project tsconfig.types-test.json",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",
     "test": "playwright test",

--- a/src/components/ConfigPanels/FlagPanel.tsx
+++ b/src/components/ConfigPanels/FlagPanel.tsx
@@ -13,7 +13,7 @@ const FlagPanel: FieldPanel<FlagField> = ({
   options = {},
   disabled = false,
 }) => {
-  const [uid, setUid] = useState(initialUid);
+  const [uid, setUid] = useState(initialUid || "");
   return (
     <Checkbox
       checked={!!uid}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,10 @@ import {
   BlockContext,
   BlockRefContext,
   ContextMenu,
+  CreateBlockArgs,
+  CreatePageArgs,
+  DeleteBlockArgs,
+  DeletePageArgs,
   FocusedBlock,
   OpenMainWindowView,
   PageContext,
@@ -21,7 +25,10 @@ import {
   SidebarWindow,
   SidebarWindowInput,
   SlashCommandApi,
-  WriteAction,
+  MoveBlockArgs,
+  UpdateBlockArgs,
+  UpdatePageArgs,
+  WriteApi,
 } from "./native";
 import {
   RunQuery,
@@ -113,13 +120,13 @@ declare global {
         id: PullEntityId,
         options?: PullOptions,
       ) => PullBlock;
-      createBlock: WriteAction;
-      updateBlock: WriteAction;
-      createPage: WriteAction;
-      moveBlock: WriteAction;
-      deleteBlock: WriteAction;
-      updatePage: WriteAction;
-      deletePage: WriteAction;
+      createBlock: WriteApi<CreateBlockArgs>;
+      updateBlock: WriteApi<UpdateBlockArgs>;
+      createPage: WriteApi<CreatePageArgs>;
+      moveBlock: WriteApi<MoveBlockArgs>;
+      deleteBlock: WriteApi<DeleteBlockArgs>;
+      updatePage: WriteApi<UpdatePageArgs>;
+      deletePage: WriteApi<DeletePageArgs>;
       util: {
         generateUID: () => string;
         dateToPageTitle: (date: Date) => string;
@@ -131,10 +138,10 @@ declare global {
         addPullWatch: AddPullWatch;
         semanticSearchEnabled: () => boolean;
         block: {
-          create: WriteAction;
-          update: WriteAction;
-          move: WriteAction;
-          delete: WriteAction;
+          create: WriteApi<CreateBlockArgs>;
+          update: WriteApi<UpdateBlockArgs>;
+          move: WriteApi<MoveBlockArgs>;
+          delete: WriteApi<DeleteBlockArgs>;
           reorderBlocks: (args: {
             location: { "parent-uid": string };
             blocks: string[];
@@ -183,9 +190,9 @@ declare global {
           q: (query: string, ...params: unknown[]) => Promise<unknown[][]>;
         };
         page: {
-          create: WriteAction;
-          update: WriteAction;
-          delete: WriteAction;
+          create: WriteApi<CreatePageArgs>;
+          update: WriteApi<UpdatePageArgs>;
+          delete: WriteApi<DeletePageArgs>;
           fromMarkdown: (args: {
             page: {
               title: string;
@@ -420,10 +427,6 @@ declare global {
           location?: { "block-uid": string; "window-id": string };
           selection?: { start: number; end?: number };
         }) => Promise<void>;
-        callout: {
-          addType: (args: { type: string }) => null;
-          removeType: (args: { type: string }) => null;
-        };
       };
       platform: {
         isDesktop: boolean;
@@ -449,14 +452,14 @@ declare global {
           file: File;
           toast?: { hide?: boolean };
         }) => Promise<string>;
-        get: {
-          (args: { url: string }): Promise<File>;
-          (args: { url: string; format: "base64" }): Promise<{
-            base64: string;
-            filename: string;
-            mimetype: string;
-          }>;
-        };
+        get: <TFormat extends "base64" | undefined = undefined>(args: {
+          url: string;
+          format?: TFormat;
+        }) => Promise<
+          TFormat extends "base64"
+            ? { base64: string; filename: string; mimetype: string }
+            : File
+        >;
         delete: (args: { url: string }) => Promise<void>;
       };
       user: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,26 @@
 import {
   AddPullWatch,
+  AiToolApi,
+  BlockContext,
+  BlockRefContext,
+  ContextMenu,
+  FocusedBlock,
+  OpenMainWindowView,
+  PageContext,
+  PageLinkContext,
+  PageRefContext,
   PullBlock,
+  PullEntityId,
+  PullOptions,
+  RoamQueryArgs,
+  RoamQueryResponse,
+  SearchArgs,
   SemanticSearch,
   SidebarAction,
+  SidebarFilterWindowInput,
   SidebarWindow,
   SidebarWindowInput,
+  SlashCommandApi,
   WriteAction,
 } from "./native";
 import {
@@ -58,6 +74,7 @@ export type InstalledExtension = {
   id: string;
   name: string;
   enabled: boolean;
+  adminEnabled: boolean;
   version: string;
 };
 
@@ -89,10 +106,12 @@ declare global {
     // END TODO remove
 
     roamAlphaAPI: {
+      apiVersion: string;
       q: (query: string, ...params: unknown[]) => unknown[][];
       pull: (
         selector: string,
-        id: number | string | [string, string],
+        id: PullEntityId,
+        options?: PullOptions,
       ) => PullBlock;
       createBlock: WriteAction;
       updateBlock: WriteAction;
@@ -119,7 +138,25 @@ declare global {
           reorderBlocks: (args: {
             location: { "parent-uid": string };
             blocks: string[];
+            "user-uid"?: string;
           }) => Promise<void>;
+          fromMarkdown: (args: {
+            location: {
+              "parent-uid": string;
+              order: number | "first" | "last";
+            };
+            "markdown-string": string;
+          }) => Promise<{ uids: string[] }>;
+          addComment: (
+            args: {
+              "block-uid": string;
+              "reply-uid"?: string;
+              "open-comment"?: boolean;
+            } & (
+              | { "reply-string": string; "reply-markdown"?: never }
+              | { "reply-string"?: never; "reply-markdown": string }
+            ),
+          ) => Promise<{ uids: string[]; parentUid: string }>;
         };
         fast: {
           q: (query: string, ...params: unknown[]) => unknown[][];
@@ -128,12 +165,15 @@ declare global {
           q: (query: string, ...params: unknown[]) => Promise<unknown[][]>;
           pull: (
             selector: string,
-            id: number | string | [string, string],
+            id: PullEntityId,
+            options?: PullOptions,
           ) => Promise<PullBlock>;
           pull_many: (
             pattern: string,
-            eids: string[][],
+            eids: PullEntityId[],
+            options?: PullOptions,
           ) => Promise<PullBlock[]>;
+          search: (args: SearchArgs) => Promise<PullBlock[]>;
           semanticSearch: SemanticSearch;
           fast: {
             q: (query: string, ...params: unknown[]) => Promise<unknown[][]>;
@@ -146,23 +186,48 @@ declare global {
           create: WriteAction;
           update: WriteAction;
           delete: WriteAction;
+          fromMarkdown: (args: {
+            page: {
+              title: string;
+              uid?: string;
+              "children-view-type"?: "bullet" | "numbered" | "document";
+            };
+            "markdown-string": string;
+          }) => Promise<{ uid: string }>;
+          addShortcut: (uid: string, index?: number) => Promise<void>;
+          removeShortcut: (uid: string) => Promise<void>;
         };
         pull: (
           selector: string,
-          id: number | string | [string, string],
+          id: PullEntityId,
+          options?: PullOptions,
         ) => PullBlock;
-        pull_many: (pattern: string, eids: string[][]) => PullBlock[];
+        pull_many: (
+          pattern: string,
+          eids: PullEntityId[],
+          options?: PullOptions,
+        ) => PullBlock[];
         q: (query: string, ...params: unknown[]) => unknown[][];
+        search: (args: SearchArgs) => PullBlock[];
+        roamQuery: (args: RoamQueryArgs) => Promise<RoamQueryResponse>;
         removePullWatch: (
-          pullPattern: string,
-          entityId: string,
-          callback?: (before: PullBlock, after: PullBlock) => void,
-        ) => boolean;
-        redo: () => void;
-        undo: () => void;
+          pullPattern?: string,
+          entityId?: string,
+          callback?: (
+            before: PullBlock | null,
+            after: PullBlock | null,
+          ) => void,
+        ) => Promise<null | true>;
+        redo: () => Promise<void>;
+        undo: () => Promise<void>;
         user: {
-          upsert: () => void;
+          upsert: (args: {
+            "user-uid": string;
+            "display-name"?: string;
+            "photo-url"?: string;
+          }) => Promise<void>;
         };
+        ai: Record<string, unknown>;
       };
       ui: {
         leftSidebar: {
@@ -190,33 +255,28 @@ declare global {
             callback: () => void;
             "disable-hotkey"?: boolean;
             "default-hotkey"?: string | string[];
-          }) => Promise<void>;
-          removeCommand: (action: { label: string }) => Promise<void>;
+          }) => Promise<null>;
+          removeCommand: (action: { label: string }) => Promise<null>;
         };
-        blockContextMenu: {
-          addCommand: (action: {
-            label: string;
-            callback: (props: {
-              "block-string": string;
-              "block-uid": string;
-              heading: 0 | 1 | 2 | 3 | null;
-              "page-uid": string;
-              "read-only?": boolean;
-              "window-id": string;
-            }) => void;
-          }) => void;
-          removeCommand: (action: { label: string }) => void;
-        };
+        slashCommand: SlashCommandApi;
+        blockContextMenu: ContextMenu<BlockContext, Promise<null>>;
+        pageContextMenu: ContextMenu<PageContext>;
+        pageRefContextMenu: ContextMenu<PageRefContext>;
+        blockRefContextMenu: ContextMenu<BlockRefContext>;
+        pageLinkContextMenu: ContextMenu<PageLinkContext>;
         individualMultiselect: {
           getSelectedUids: () => string[];
+        };
+        multiselect: {
+          getSelected: () => FocusedBlock[];
         };
         msContextMenu: {
           addCommand: (action: {
             label: string;
             callback: () => void;
             "display-conditional"?: () => boolean;
-          }) => void;
-          removeCommand: (action: { label: string }) => void;
+          }) => null;
+          removeCommand: (action: { label: string }) => null;
         };
         filters: {
           addGlobalFilter: (args: {
@@ -240,7 +300,9 @@ declare global {
             includes: string[];
             removes: string[];
           };
-          getSidebarWindowFilters: (args: { window: SidebarWindowInput }) => {
+          getSidebarWindowFilters: (args: {
+            window: SidebarFilterWindowInput;
+          }) => {
             includes: string[];
             removes: string[];
           };
@@ -253,20 +315,18 @@ declare global {
             filters: { includes?: string[]; removes?: string[] };
           }) => Promise<void>;
           setSidebarWindowFilters: (args: {
-            window: SidebarWindowInput;
+            window: SidebarFilterWindowInput;
             filters: { includes?: string[]; removes?: string[] };
           }) => Promise<void>;
         };
-        getFocusedBlock: () => null | {
-          "window-id": string;
-          "block-uid": string;
-        };
+        getFocusedBlock: () => FocusedBlock | null;
         components: {
           renderBlock: (args: {
             uid: string;
             el: HTMLElement;
             "zoom-path?"?: boolean;
             "open?"?: boolean;
+            "zoom-start-after-uid"?: string;
           }) => Promise<null>;
           renderPage: (args: {
             uid: string;
@@ -294,17 +354,19 @@ declare global {
             zoomPath?: boolean;
             zoomStartAfterUid?: string;
           }) => JSX.Element;
-          Page: (props:
-            | {
-                uid: string;
-                title?: never;
-                hideMentions?: boolean;
-              }
-            | {
-                uid?: never;
-                title: string;
-                hideMentions?: boolean;
-              }) => JSX.Element;
+          Page: (
+            props:
+              | {
+                  uid: string;
+                  title?: never;
+                  hideMentions?: boolean;
+                }
+              | {
+                  uid?: never;
+                  title: string;
+                  hideMentions?: boolean;
+                },
+          ) => JSX.Element;
           Search: (props: {
             searchQueryStr: string;
             closed?: boolean;
@@ -316,9 +378,7 @@ declare global {
               hidePaths?: boolean;
             }) => void;
           }) => JSX.Element;
-          BlockString: (props: {
-            string: string;
-          }) => JSX.Element;
+          BlockString: (props: { string: string }) => JSX.Element;
         };
         graphView: {
           addCallback: (props: {
@@ -329,14 +389,14 @@ declare global {
               type: "page" | "all-pages";
             }) => void;
             type?: "page" | "all-pages";
-          }) => Promise<void>;
-          removeCallback: (props: { label: string }) => Promise<void>;
+          }) => void;
+          removeCallback: (props: { label: string }) => null;
           wholeGraph: {
             addCallback: (props: {
               label: string;
               callback: (arg: { "sigma-renderer": unknown }) => void;
-            }) => any;
-            removeCallback: (props: { label: string }) => void;
+            }) => null;
+            removeCallback: (props: { label: string }) => null;
             setExplorePages: (pages: string[]) => void;
             getExplorePages: () => string[];
             setMode: (mode: "Whole Graph" | "Explore") => void;
@@ -349,12 +409,21 @@ declare global {
             page: { uid: string } | { title: string };
           }) => Promise<void>;
           getOpenPageOrBlockUid: () => Promise<string | null>;
+          getOpenView: () => Promise<OpenMainWindowView>;
           openDailyNotes: () => Promise<void>;
+          registerComponent: (id: string, component: React.ElementType) => void;
+          unregisterComponent: (id: string) => void;
+          openComponent: (id: string, ...args: unknown[]) => void;
+          closeComponent: (id: string) => void;
         };
         setBlockFocusAndSelection: (a: {
           location?: { "block-uid": string; "window-id": string };
           selection?: { start: number; end?: number };
         }) => Promise<void>;
+        callout: {
+          addType: (args: { type: string }) => null;
+          removeType: (args: { type: string }) => null;
+        };
       };
       platform: {
         isDesktop: boolean;
@@ -371,18 +440,30 @@ declare global {
       };
       depot: {
         getInstalledExtensions: () => Record<string, InstalledExtension>;
+        reloadDeveloperExtensions: () => Promise<{
+          reloaded: { id: string; name: string }[];
+        }>;
       };
       file: {
         upload: (args: {
           file: File;
-          toast?: { hide: boolean };
+          toast?: { hide?: boolean };
         }) => Promise<string>;
-        get: (args: { url: string }) => Promise<File>;
+        get: {
+          (args: { url: string }): Promise<File>;
+          (args: { url: string; format: "base64" }): Promise<{
+            base64: string;
+            filename: string;
+            mimetype: string;
+          }>;
+        };
         delete: (args: { url: string }) => Promise<void>;
       };
       user: {
         uid: () => string | null;
+        isAdmin: () => boolean;
       };
+      ai: AiToolApi;
       constants: {
         corsAnywhereProxyUrl: string;
       };
@@ -416,4 +497,3 @@ declare global {
     };
   }
 }
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import {
   AddPullWatch,
   AiToolApi,
+  Base64File,
   BlockContext,
   BlockRefContext,
   ContextMenu,
@@ -8,6 +9,7 @@ import {
   CreatePageArgs,
   DeleteBlockArgs,
   DeletePageArgs,
+  DeleteResult,
   FocusedBlock,
   OpenMainWindowView,
   PageContext,
@@ -127,9 +129,9 @@ declare global {
       updateBlock: WriteApi<UpdateBlockArgs>;
       createPage: WriteApi<CreatePageArgs>;
       moveBlock: WriteApi<MoveBlockArgs>;
-      deleteBlock: WriteApi<DeleteBlockArgs>;
+      deleteBlock: WriteApi<DeleteBlockArgs, DeleteResult>;
       updatePage: WriteApi<UpdatePageArgs>;
-      deletePage: WriteApi<DeletePageArgs>;
+      deletePage: WriteApi<DeletePageArgs, DeleteResult>;
       util: {
         generateUID: () => string;
         dateToPageTitle: (date: Date) => string;
@@ -144,7 +146,7 @@ declare global {
           create: WriteApi<CreateBlockArgs>;
           update: WriteApi<UpdateBlockArgs>;
           move: WriteApi<MoveBlockArgs>;
-          delete: WriteApi<DeleteBlockArgs>;
+          delete: WriteApi<DeleteBlockArgs, DeleteResult>;
           reorderBlocks: (args: {
             location: { "parent-uid": string };
             blocks: string[];
@@ -195,7 +197,7 @@ declare global {
         page: {
           create: WriteApi<CreatePageArgs>;
           update: WriteApi<UpdatePageArgs>;
-          delete: WriteApi<DeletePageArgs>;
+          delete: WriteApi<DeletePageArgs, DeleteResult>;
           fromMarkdown: (args: {
             page: {
               title: string;
@@ -233,6 +235,10 @@ declare global {
         ai: Record<string, unknown>;
       };
       ui: {
+        callout: {
+          addType: (args: { type: string }) => null;
+          removeType: (args: { type: string }) => null;
+        };
         leftSidebar: {
           open: () => Promise<void>;
           close: () => Promise<void>;
@@ -444,14 +450,13 @@ declare global {
           file: File;
           toast?: { hide?: boolean };
         }) => Promise<string>;
-        get: <TFormat extends "base64" | undefined = undefined>(args: {
-          url: string;
-          format?: TFormat;
-        }) => Promise<
-          TFormat extends "base64"
-            ? { base64: string; filename: string; mimetype: string }
-            : File
-        >;
+        get: {
+          (args: { url: string; format: "base64" }): Promise<Base64File>;
+          (args: { url: string; format?: undefined }): Promise<File>;
+          (args: { url: string; format?: "base64" }): Promise<
+            File | Base64File
+          >;
+        };
         delete: (args: { url: string }) => Promise<void>;
       };
       user: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,12 +16,15 @@ import {
   PullBlock,
   PullEntityId,
   PullOptions,
+  RemovePullWatch,
+  RenderBlockArgs,
   RoamQueryArgs,
   RoamQueryResponse,
   SearchArgs,
   SemanticSearch,
   SidebarAction,
   SidebarFilterWindowInput,
+  SidebarOrderedWindowInput,
   SidebarWindow,
   SidebarWindowInput,
   SlashCommandApi,
@@ -217,14 +220,7 @@ declare global {
         q: (query: string, ...params: unknown[]) => unknown[][];
         search: (args: SearchArgs) => PullBlock[];
         roamQuery: (args: RoamQueryArgs) => Promise<RoamQueryResponse>;
-        removePullWatch: (
-          pullPattern?: string,
-          entityId?: string,
-          callback?: (
-            before: PullBlock | null,
-            after: PullBlock | null,
-          ) => void,
-        ) => Promise<null | true>;
+        removePullWatch: RemovePullWatch;
         redo: () => Promise<void>;
         undo: () => Promise<void>;
         user: {
@@ -246,7 +242,9 @@ declare global {
           close: () => Promise<void>;
           getWindows: () => SidebarWindow[];
           addWindow: SidebarAction;
-          setWindowOrder: SidebarAction;
+          setWindowOrder: (action: {
+            window: SidebarOrderedWindowInput;
+          }) => Promise<void>;
           collapseWindow: SidebarAction;
           pinWindow: (action: {
             window: SidebarWindowInput;
@@ -328,13 +326,7 @@ declare global {
         };
         getFocusedBlock: () => FocusedBlock | null;
         components: {
-          renderBlock: (args: {
-            uid: string;
-            el: HTMLElement;
-            "zoom-path?"?: boolean;
-            "open?"?: boolean;
-            "zoom-start-after-uid"?: string;
-          }) => Promise<null>;
+          renderBlock: (args: RenderBlockArgs) => Promise<null>;
           renderPage: (args: {
             uid: string;
             el: HTMLElement;

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -464,6 +464,7 @@ type BlockDisplayProperties = {
   "text-align"?: TextAlignment;
   "children-view-type"?: ViewType;
   "block-view-type"?: Exclude<BlockViewType, "horizontal">;
+  props?: Record<string, unknown>;
 };
 
 type WriteAttribution = {
@@ -542,6 +543,10 @@ export type SidebarWindowInput = SidebarWindowInputType & {
   order?: number;
 };
 
+export type SidebarOrderedWindowInput = SidebarWindowInputType & {
+  order: number;
+};
+
 export type SidebarFilterWindowInput = Exclude<
   SidebarWindowInputType,
   SidebarSearchQueryWindow
@@ -614,6 +619,20 @@ export type AddPullWatch = (
   callback: (before: PullBlock | null, after: PullBlock | null) => void,
 ) => Promise<null>;
 
+type PullWatchCallback = (
+  before: PullBlock | null,
+  after: PullBlock | null,
+) => void;
+
+type RemovePullWatchArgs =
+  | []
+  | [pullPattern: string, entityId: string]
+  | [pullPattern: string, entityId: string, callback: PullWatchCallback];
+
+export type RemovePullWatch = <TArgs extends RemovePullWatchArgs>(
+  ...args: TArgs
+) => Promise<TArgs extends [string, string] ? true : null>;
+
 export type PullEntityId = number | string | [string, string];
 
 export type PullOptions = {
@@ -640,24 +659,28 @@ export type RoamQueryArgs =
       limit?: number | null;
       pull?: string;
     }
-  | {
+  | ({
       uid?: never;
       query: string;
-      groupByPage?: boolean;
       nestUnderParent?: boolean;
-      sort?:
-        | "page-most-recent"
-        | "page-title"
-        | "page-created-date"
-        | "daily-note"
-        | "created-date"
-        | "edited-date"
-        | "daily-note-date";
       sortOrder?: "asc" | "desc";
       offset?: number;
       limit?: number | null;
       pull?: string;
-    };
+    } & (
+      | {
+          groupByPage?: true;
+          sort?:
+            | "page-most-recent"
+            | "page-title"
+            | "page-created-date"
+            | "daily-note";
+        }
+      | {
+          groupByPage: false;
+          sort?: "created-date" | "edited-date" | "daily-note-date";
+        }
+    ));
 
 export type RoamQueryResponse = {
   total: number;
@@ -749,8 +772,25 @@ export type JsonValue =
 
 export type AiToolContext = {
   tokenUserUid?: string;
-  asTokenUser: <T>(callback: () => T) => T;
+  asTokenUser: <T>(
+    callback: () => T & (T extends PromiseLike<unknown> ? never : unknown),
+  ) => T;
 };
+
+export type RenderBlockArgs = {
+  uid: string;
+  el: HTMLElement;
+  "open?"?: boolean;
+} & (
+  | {
+      "zoom-path?": true;
+      "zoom-start-after-uid"?: string;
+    }
+  | {
+      "zoom-path?"?: false;
+      "zoom-start-after-uid"?: never;
+    }
+);
 
 export type AiToolDefinition = {
   name: string;

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -1,7 +1,11 @@
 // emulating Datalog Grammar
 // https://docs.datomic.com/cloud/query/query-data-reference.html#or-clauses
 
-import { ChangeEvent } from "react";
+import type {
+  ChangeEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactElement,
+} from "react";
 
 export type DatalogSrcVar = {
   type: "src-var";
@@ -332,8 +336,11 @@ export type RoamError = {
   "status-code": number;
 };
 
-export type SemanticSearchArgs = {
-  "search-str": string;
+type SearchString =
+  | { "search-str": string; "search-string"?: never }
+  | { "search-str"?: never; "search-string": string };
+
+export type SemanticSearchArgs = SearchString & {
   k?: number;
   "search-blocks"?: boolean;
   "search-pages"?: boolean;
@@ -430,7 +437,7 @@ export type ClientParams = {
 export type ActionParams = {
   location?: {
     "parent-uid": string;
-    order: number | "last";
+    order: number | "first" | "last";
   };
   block?: {
     string?: string;
@@ -440,11 +447,14 @@ export type ActionParams = {
     "text-align"?: TextAlignment;
     "children-view-type"?: ViewType;
     "block-view-type"?: BlockViewType;
+    "user-uid"?: string;
     props?: Record<string, unknown>;
   };
   page?: {
     title?: string;
     uid?: string;
+    "children-view-type"?: ViewType;
+    "user-uid"?: string;
     props?: Record<string, unknown>;
   };
 };
@@ -458,16 +468,21 @@ export type UserSettings = {
   };
 };
 
-type SidebarWindowType =
+type SidebarWindowInputType =
   | SidebarBlockWindow
   | SidebarMentionsWindow
   | SidebarGraphWindow
   | SidebarOutlineWindow
   | SidebarSearchQueryWindow;
 
-export type SidebarWindowInput = SidebarWindowType & {
+export type SidebarWindowInput = SidebarWindowInputType & {
   order?: number;
 };
+
+export type SidebarFilterWindowInput = Exclude<
+  SidebarWindowInputType,
+  SidebarSearchQueryWindow
+>;
 
 type SidebarBlockWindow = {
   type: "block";
@@ -476,23 +491,22 @@ type SidebarBlockWindow = {
 
 type SidebarOutlineWindow = {
   type: "outline";
-  "page-uid": string;
+  "block-uid": string;
 };
 
 type SidebarMentionsWindow = {
   type: "mentions";
-  "mentions-uid": string;
+  "block-uid": string;
 };
 
 type SidebarGraphWindow = {
   type: "graph";
-  // "page-uid": string; Currently not working despite documentation
   "block-uid": string;
 };
 
 type SidebarSearchQueryWindow = {
   type: "search-query";
-  "search-query-uid": string;
+  "search-query-str": string;
 };
 
 export type SidebarAction = (action: {
@@ -503,19 +517,193 @@ export type SidebarWindow = {
   "collapsed?": boolean;
   order: number;
   "pinned?": boolean;
+  "pinned-to-top?": boolean;
   "window-id": string;
-} & SidebarWindowType;
+} & (
+  | {
+      type: "block";
+      "block-uid": string;
+      "block-string": string;
+    }
+  | {
+      type: "outline" | "graph";
+      "page-uid": string;
+      title: string;
+    }
+  | {
+      type: "mentions";
+      "mentions-uid": string;
+    }
+  | {
+      type: "mentions";
+      "page-uid": string;
+      title: string;
+    }
+  | {
+      type: "search-query";
+      "search-query-str": string;
+    }
+);
 
 export type AddPullWatch = (
   pullPattern: string,
   entityId: string,
   callback: (before: PullBlock | null, after: PullBlock | null) => void,
-) => boolean;
+) => Promise<null>;
+
+export type PullEntityId = number | string | [string, string];
+
+export type PullOptions = {
+  timeout?: number;
+};
+
+export type SearchArgs = SearchString & {
+  "search-blocks"?: boolean;
+  "search-pages"?: boolean;
+  "hide-code-blocks"?: boolean;
+  limit?: number;
+  pull?: string | unknown[];
+};
+
+export type RoamQueryArgs =
+  | {
+      uid: string;
+      offset?: number;
+      limit?: number | null;
+      pull?: string;
+    }
+  | {
+      query: string;
+      groupByPage?: boolean;
+      nestUnderParent?: boolean;
+      sort?:
+        | "page-most-recent"
+        | "page-title"
+        | "page-created-date"
+        | "daily-note"
+        | "created-date"
+        | "edited-date"
+        | "daily-note-date";
+      sortOrder?: "asc" | "desc";
+      offset?: number;
+      limit?: number | null;
+      pull?: string;
+    };
+
+export type RoamQueryResponse = {
+  total: number;
+  results: PullBlock[];
+};
+
+export type FocusedBlock = {
+  "block-uid": string;
+  "window-id": string;
+};
+
+export type SlashCommandContext = FocusedBlock & {
+  indexes: [number, number];
+};
+
+export type BlockContext = FocusedBlock & {
+  "block-string": string;
+  heading: 0 | 1 | 2 | 3 | null;
+  "page-uid": string;
+  "read-only?": boolean;
+};
+
+export type PageContext = {
+  "page-uid": string;
+  "page-title": string;
+  "window-id": string;
+};
+
+export type PageLinkContext = Pick<PageContext, "page-uid" | "page-title">;
+
+export type BlockRefContext = FocusedBlock & {
+  "ref-uid": string;
+  indexes: [number, number];
+};
+
+export type PageRefContext = BlockRefContext & {
+  type: "page-ref" | "attribute" | "tag" | "multitag" | "inline-link";
+};
+
+export type MenuCommand<TContext> = {
+  label: string;
+  callback: (context: TContext) => void;
+  "display-conditional"?: (context: TContext) => boolean;
+};
+
+export type ContextMenu<TContext, TReturn = null> = {
+  addCommand: (action: MenuCommand<TContext>) => TReturn;
+  removeCommand: (action: { label: string }) => TReturn;
+};
+
+export type SlashCommandApi = {
+  addCommand: (action: {
+    label: string;
+    callback: (context: SlashCommandContext) => string | null;
+    "display-conditional"?: (
+      context: Omit<SlashCommandContext, "indexes">,
+    ) => boolean;
+  }) => null;
+  removeCommand: (action: { label: string }) => null;
+};
+
+export type OpenMainWindowView =
+  | {
+      type: "outline";
+      uid: string;
+      title: string;
+    }
+  | {
+      type: "outline";
+      uid: string;
+      "block-string": string;
+    }
+  | {
+      type: "log";
+      uids: string[];
+    }
+  | { type: "graph" }
+  | { type: "diagram"; uid: string }
+  | { type: "pdf"; uid: string; url: string }
+  | { type: "search" }
+  | { type: "custom"; id: string; args: unknown[] };
+
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type AiToolContext = {
+  tokenUserUid?: string;
+  asTokenUser: <T>(callback: () => T) => T;
+};
+
+export type AiToolDefinition = {
+  name: string;
+  description: string;
+  handler: (
+    args: Record<string, unknown>,
+    context: AiToolContext,
+  ) => JsonValue | Promise<JsonValue>;
+  scope?: "read" | "append" | "edit";
+  inputSchema?: Record<string, JsonValue>;
+};
+
+export type AiToolApi = {
+  addTool: (tool: AiToolDefinition) => null;
+  removeTool: (args: { name: string }) => null;
+};
 
 type ButtonAction = {
   type: "button";
-  onClick?: (e: MouseEvent) => void;
+  onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
   content: string;
+  class?: string;
 };
 
 type SwitchAction = {
@@ -532,7 +720,7 @@ type InputAction = {
 type SelectAction = {
   type: "select";
   items: string[];
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (item: string) => void;
 };
 
 type CustomAction = {
@@ -551,8 +739,9 @@ type PanelConfig = {
   tabTitle: string;
   settings: {
     id: string;
-    name: string;
-    description: string;
+    name: string | ReactElement;
+    description?: string | ReactElement;
+    className?: string;
     action: Action;
   }[];
 };
@@ -560,31 +749,36 @@ type PanelConfig = {
 export type AddCommandOptions = {
   label: string;
   callback: () => void;
-  disableHotkey?: boolean;
-  defaultHotkey?: string | string[];
+  "disable-hotkey"?: boolean;
+  "default-hotkey"?: string | string[];
 };
 
-type RemoveCommandOptions = {
+export type RemoveCommandOptions = {
   label: string;
 };
 
-export type OnloadArgs = {
-  extensionAPI: {
-    settings: {
-      get: (k: string) => unknown;
-      getAll: () => Record<string, unknown>;
-      panel: {
-        create: (c: PanelConfig) => void;
-      };
-      set: (k: string, v: unknown) => Promise<void>;
+export type ExtensionAPI = {
+  settings: {
+    canSet: boolean;
+    get: (key: string) => JsonValue | null;
+    getAll: () => Record<string, JsonValue> | null;
+    panel: {
+      create: (config: PanelConfig) => Promise<null>;
     };
-    ui: {
-      commandPalette: {
-        addCommand: (c: AddCommandOptions) => Promise<void>;
-        removeCommand: (c: RemoveCommandOptions) => Promise<void>;
-      };
-    };
+    set: (key: string, value: JsonValue) => Promise<null>;
   };
+  ui: {
+    commandPalette: {
+      addCommand: (command: AddCommandOptions) => Promise<null>;
+      removeCommand: (command: RemoveCommandOptions) => Promise<null>;
+    };
+    slashCommand: SlashCommandApi;
+  };
+  ai: AiToolApi;
+};
+
+export type OnloadArgs = {
+  extensionAPI: ExtensionAPI;
   extension: {
     version: string;
   };

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -1,11 +1,7 @@
 // emulating Datalog Grammar
 // https://docs.datomic.com/cloud/query/query-data-reference.html#or-clauses
 
-import type {
-  ChangeEvent,
-  MouseEvent as ReactMouseEvent,
-  ReactElement,
-} from "react";
+import type { ChangeEvent, ReactElement } from "react";
 
 export type DatalogSrcVar = {
   type: "src-var";
@@ -241,6 +237,7 @@ export type RoamPull = {
 } & RoamNode;
 
 export type PullBlock = {
+  [key: string]: unknown;
   ":attrs/lookup"?: PullBlock[];
   ":entity/attrs"?: [
     { ":source": [":block/uid", string]; ":value": [":block/uid", string] },
@@ -461,6 +458,72 @@ export type ActionParams = {
 
 export type WriteAction = (a: ActionParams) => Promise<void>;
 
+type BlockDisplayProperties = {
+  open?: boolean;
+  heading?: 0 | 1 | 2 | 3;
+  "text-align"?: TextAlignment;
+  "children-view-type"?: ViewType;
+  "block-view-type"?: Exclude<BlockViewType, "horizontal">;
+};
+
+type WriteAttribution = {
+  "user-uid"?: string;
+};
+
+export type CreateBlockArgs = {
+  location: {
+    "parent-uid": string;
+    order: number | "first" | "last";
+  };
+  block: BlockDisplayProperties &
+    WriteAttribution & {
+      string: string;
+      uid?: string;
+    };
+};
+
+export type UpdateBlockArgs = {
+  block: BlockDisplayProperties &
+    WriteAttribution & {
+      uid: string;
+      string?: string;
+    };
+};
+
+export type MoveBlockArgs = {
+  location: {
+    "parent-uid": string;
+    order: number | "first" | "last";
+  };
+  block: WriteAttribution & { uid: string };
+};
+
+export type DeleteBlockArgs = {
+  block: WriteAttribution & { uid: string };
+};
+
+export type CreatePageArgs = {
+  page: WriteAttribution & {
+    title: string;
+    uid?: string;
+    "children-view-type"?: ViewType;
+  };
+};
+
+export type UpdatePageArgs = {
+  page: WriteAttribution & {
+    uid: string;
+    title?: string;
+    "children-view-type"?: ViewType;
+  };
+};
+
+export type DeletePageArgs = {
+  page: WriteAttribution & { uid: string };
+};
+
+export type WriteApi<TArgs> = (args: TArgs) => Promise<void>;
+
 export type UserSettings = {
   "global-filters": {
     includes: string[];
@@ -568,11 +631,17 @@ export type SearchArgs = SearchString & {
 export type RoamQueryArgs =
   | {
       uid: string;
+      query?: never;
+      groupByPage?: never;
+      nestUnderParent?: never;
+      sort?: never;
+      sortOrder?: never;
       offset?: number;
       limit?: number | null;
       pull?: string;
     }
   | {
+      uid?: never;
       query: string;
       groupByPage?: boolean;
       nestUnderParent?: boolean;
@@ -701,7 +770,7 @@ export type AiToolApi = {
 
 type ButtonAction = {
   type: "button";
-  onClick?: (e: ReactMouseEvent<HTMLElement>) => void;
+  onClick?: (e: MouseEvent) => void;
   content: string;
   class?: string;
 };

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -680,6 +680,10 @@ export type RoamQueryArgs =
           groupByPage: false;
           sort?: "created-date" | "edited-date" | "daily-note-date";
         }
+      | {
+          groupByPage: boolean;
+          sort?: never;
+        }
     ));
 
 export type RoamQueryResponse = {
@@ -788,6 +792,10 @@ export type RenderBlockArgs = {
     }
   | {
       "zoom-path?"?: false;
+      "zoom-start-after-uid"?: never;
+    }
+  | {
+      "zoom-path?": boolean;
       "zoom-start-after-uid"?: never;
     }
 );

--- a/src/types/native.ts
+++ b/src/types/native.ts
@@ -508,6 +508,7 @@ export type CreatePageArgs = {
     title: string;
     uid?: string;
     "children-view-type"?: ViewType;
+    props?: Record<string, unknown>;
   };
 };
 
@@ -516,6 +517,7 @@ export type UpdatePageArgs = {
     uid: string;
     title?: string;
     "children-view-type"?: ViewType;
+    props?: Record<string, unknown>;
   };
 };
 
@@ -523,7 +525,17 @@ export type DeletePageArgs = {
   page: WriteAttribution & { uid: string };
 };
 
-export type WriteApi<TArgs> = (args: TArgs) => Promise<void>;
+export type DeleteResult =
+  | { deleted: true }
+  | { deleted: false; reason: string };
+
+export type WriteApi<TArgs, TResult = void> = (args: TArgs) => Promise<TResult>;
+
+export type Base64File = {
+  base64: string;
+  filename: string;
+  mimetype: string;
+};
 
 export type UserSettings = {
   "global-filters": {
@@ -776,9 +788,12 @@ export type JsonValue =
 
 export type AiToolContext = {
   tokenUserUid?: string;
-  asTokenUser: <T>(
-    callback: () => T & (T extends PromiseLike<unknown> ? never : unknown),
-  ) => T;
+  /**
+   * Issue writes synchronously inside the callback; await its return value outside.
+   * Do not pass an async callback: writes after its first await lose AI attribution.
+   * TypeScript cannot distinguish it from a synchronous callback returning a promise.
+   */
+  asTokenUser: <T>(callback: () => T) => T;
 };
 
 export type RenderBlockArgs = {

--- a/src/writes/submitActions.ts
+++ b/src/writes/submitActions.ts
@@ -1,4 +1,4 @@
-import type { ActionParams } from "../types";
+import type { ActionParams, WriteAction } from "../types";
 import { ID, render as renderProgressDialog } from "../components/ProgressDialog";
 import nanoid from "nanoid";
 
@@ -26,7 +26,7 @@ const submitActions = (
           const { params, type } = action;
           const id = nanoid();
           const fire = () =>
-            window.roamAlphaAPI[type](params)
+            (window.roamAlphaAPI[type] as WriteAction)(params)
               .then(resolve)
               .catch((e) => {
                 if (e.code === "busy") {

--- a/tests/types/api-review-regressions.ts
+++ b/tests/types/api-review-regressions.ts
@@ -1,0 +1,113 @@
+import type { AiToolContext, OnloadArgs } from "../../src/types";
+
+const assertType = <T extends true>(assertion: T): void => {
+  void assertion;
+};
+type IsExact<T, U> = (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U
+  ? 1
+  : 2
+  ? true
+  : false;
+
+type ExpectedBase64File = {
+  base64: string;
+  filename: string;
+  mimetype: string;
+};
+type ExpectedDeleteResult =
+  | { deleted: true }
+  | { deleted: false; reason: string };
+
+// Compile-only consumer examples; never execute these graph writes.
+export const exerciseReviewRegressions = async ({
+  context,
+  extensionAPI,
+  options,
+}: {
+  context: AiToolContext;
+  extensionAPI: OnloadArgs["extensionAPI"];
+  options: { url: string; format?: "base64" };
+}): Promise<void> => {
+  const api = window.roamAlphaAPI;
+  const url = "https://example.com/file";
+  const defaultFile = await api.file.get({ url });
+  const base64File = await api.file.get({ url, format: "base64" });
+  const explicitUndefinedFile = await api.file.get({ url, format: undefined });
+  const format = Date.now() % 2 === 0 ? ("base64" as const) : undefined;
+  const optionalFormatFile = await api.file.get({ url, format });
+  const optionalOptionsFile = await api.file.get(options);
+
+  // @ts-expect-error An optional format may produce a File, which has no base64 field.
+  optionalOptionsFile.base64.toUpperCase();
+  // @ts-expect-error A computed format must be narrowed before accessing base64.
+  optionalFormatFile.base64.toUpperCase();
+  // @ts-expect-error Only base64 is a supported format override.
+  api.file.get({ url, format: "text" });
+
+  await api.data.page.create({
+    page: { title: "Example", props: { custom: true } },
+  });
+  await api.data.page.update({
+    page: { uid: "abc123xyz", props: { custom: true } },
+  });
+  await api.createPage({ page: { title: "Legacy", props: { custom: true } } });
+  await api.updatePage({ page: { uid: "abc123xyz", props: { custom: true } } });
+
+  const deleteBlock = await api.data.block.delete({
+    block: { uid: "abc123xyz" },
+  });
+  const deletePage = await api.data.page.delete({ page: { uid: "abc123xyz" } });
+  const legacyDeleteBlock = await api.deleteBlock({
+    block: { uid: "abc123xyz" },
+  });
+  const legacyDeletePage = await api.deletePage({ page: { uid: "abc123xyz" } });
+  if (!deleteBlock.deleted) {
+    deleteBlock.reason.toUpperCase();
+  } else {
+    // @ts-expect-error A successful deletion does not have a failure reason.
+    void deleteBlock.reason;
+  }
+
+  const writePromise = context.asTokenUser(() =>
+    api.data.block.update({ block: { uid: "abc123xyz", string: "Updated" } }),
+  );
+  const scalar = context.asTokenUser(() => 42);
+  await writePromise;
+  extensionAPI.ai.addTool({
+    name: "update-block",
+    description: "Update a block with AI attribution.",
+    handler: async (_args, toolContext) => {
+      await toolContext.asTokenUser(() =>
+        api.data.block.update({
+          block: { uid: "abc123xyz", string: "Updated" },
+        }),
+      );
+      return { updated: true };
+    },
+  });
+
+  const addCalloutType = api.ui.callout.addType({ type: "recipe" });
+  const removeCalloutType = api.ui.callout.removeType({ type: "recipe" });
+  // @ts-expect-error Callout registration requires a type name.
+  api.ui.callout.addType({});
+  // @ts-expect-error Callout removal requires a string type name.
+  api.ui.callout.removeType({ type: 42 });
+
+  assertType<IsExact<typeof defaultFile, File>>(true);
+  assertType<IsExact<typeof base64File, ExpectedBase64File>>(true);
+  assertType<IsExact<typeof explicitUndefinedFile, File>>(true);
+  assertType<IsExact<typeof optionalFormatFile, File | ExpectedBase64File>>(
+    true,
+  );
+  assertType<IsExact<typeof optionalOptionsFile, File | ExpectedBase64File>>(
+    true,
+  );
+  assertType<IsExact<typeof deleteBlock, ExpectedDeleteResult>>(true);
+  assertType<IsExact<typeof deletePage, ExpectedDeleteResult>>(true);
+  assertType<IsExact<typeof legacyDeleteBlock, ExpectedDeleteResult>>(true);
+  assertType<IsExact<typeof legacyDeletePage, ExpectedDeleteResult>>(true);
+  assertType<IsExact<typeof writePromise, Promise<void>>>(true);
+  assertType<IsExact<typeof scalar, number>>(true);
+  assertType<IsExact<typeof addCalloutType, null>>(true);
+  assertType<IsExact<typeof removeCalloutType, null>>(true);
+};

--- a/tests/types/documented-api.ts
+++ b/tests/types/documented-api.ts
@@ -36,9 +36,6 @@ type SetWindowOrderArgs = Parameters<
 type RenderBlockArgs = Parameters<
   typeof window.roamAlphaAPI.ui.components.renderBlock
 >[0];
-type AsTokenUser = Parameters<
-  Parameters<typeof window.roamAlphaAPI.ai.addTool>[0]["handler"]
->[1]["asTokenUser"];
 type RemovePullWatchArgs = Parameters<
   typeof window.roamAlphaAPI.data.removePullWatch
 >;
@@ -124,9 +121,6 @@ type RenderBlockComputedZoomPathStillRejectsStartUid = AssertFalse<
     },
     RenderBlockArgs
   >
->;
-type AsyncTokenUserCallbackIsRejected = AssertFalse<
-  IsAssignable<(callback: () => Promise<void>) => Promise<void>, AsTokenUser>
 >;
 type PartialRemovePullWatchIsRejected = AssertFalse<
   IsAssignable<[pullPattern: string], RemovePullWatchArgs>
@@ -337,7 +331,6 @@ export type DocumentedApiTypeAssertions =
   | RenderBlockZoomStartRequiresZoomPath
   | RenderBlockAcceptsComputedZoomPathWithoutStartUid
   | RenderBlockComputedZoomPathStillRejectsStartUid
-  | AsyncTokenUserCallbackIsRejected
   | PartialRemovePullWatchIsRejected
   | BlockPropsRemainSupported
   | QueryResultIsExact

--- a/tests/types/documented-api.ts
+++ b/tests/types/documented-api.ts
@@ -1,0 +1,145 @@
+import type { OnloadArgs } from "../../src/types";
+import type { FC } from "react";
+
+export const exerciseDocumentedApis = async ({
+  extensionAPI,
+}: OnloadArgs): Promise<void> => {
+  const apiVersion: string = window.roamAlphaAPI.apiVersion;
+  const pullResult = window.roamAlphaAPI.data.pull(
+    "[*]",
+    [":block/uid", "abc123xyz"],
+    { timeout: 60_000 },
+  );
+  const searchResults = window.roamAlphaAPI.data.search({
+    "search-str": "project",
+    limit: 50,
+  });
+  const asyncSearchResults = await window.roamAlphaAPI.data.async.search({
+    "search-string": "project",
+  });
+  const queryResults = await window.roamAlphaAPI.data.roamQuery({
+    query: "{and: [[project]] [[active]]}",
+    groupByPage: true,
+    sort: "page-most-recent",
+  });
+
+  await window.roamAlphaAPI.data.addPullWatch(
+    "[:block/string]",
+    '[:block/uid "abc123xyz"]',
+    () => undefined,
+  );
+  await window.roamAlphaAPI.data.removePullWatch();
+  await window.roamAlphaAPI.data.block.fromMarkdown({
+    location: { "parent-uid": "abc123xyz", order: "last" },
+    "markdown-string": "- First block",
+  });
+  await window.roamAlphaAPI.data.block.addComment({
+    "block-uid": "abc123xyz",
+    "reply-string": "A comment",
+  });
+  await window.roamAlphaAPI.data.page.fromMarkdown({
+    page: { title: "New page", "children-view-type": "document" },
+    "markdown-string": "# Heading",
+  });
+  await window.roamAlphaAPI.data.page.addShortcut("abc123xyz", 0);
+  await window.roamAlphaAPI.data.page.removeShortcut("abc123xyz");
+  await window.roamAlphaAPI.data.user.upsert({
+    "user-uid": "user123",
+    "display-name": "User",
+  });
+
+  window.roamAlphaAPI.ui.slashCommand.addCommand({
+    label: "Insert greeting",
+    callback: ({ indexes }) => (indexes.length ? "Hello" : null),
+  });
+  await window.roamAlphaAPI.ui.blockContextMenu.addCommand({
+    label: "Inspect block",
+    "display-conditional": (context) => !context["read-only?"],
+    callback: ({ "block-uid": blockUid }) => void blockUid,
+  });
+  window.roamAlphaAPI.ui.pageContextMenu.addCommand({
+    label: "Inspect page",
+    callback: ({ "page-uid": pageUid }) => void pageUid,
+  });
+  window.roamAlphaAPI.ui.pageRefContextMenu.addCommand({
+    label: "Inspect page reference",
+    callback: ({ type }) => void type,
+  });
+  window.roamAlphaAPI.ui.blockRefContextMenu.addCommand({
+    label: "Inspect block reference",
+    callback: ({ "ref-uid": refUid }) => void refUid,
+  });
+  window.roamAlphaAPI.ui.pageLinkContextMenu.addCommand({
+    label: "Inspect page link",
+    callback: ({ "page-title": pageTitle }) => void pageTitle,
+  });
+  const selectedBlocks = window.roamAlphaAPI.ui.multiselect.getSelected();
+  const openView = await window.roamAlphaAPI.ui.mainWindow.getOpenView();
+  const Component: FC = () => null;
+  window.roamAlphaAPI.ui.mainWindow.registerComponent("custom-view", Component);
+  window.roamAlphaAPI.ui.mainWindow.openComponent("custom-view", "argument");
+  window.roamAlphaAPI.ui.mainWindow.closeComponent("custom-view");
+  window.roamAlphaAPI.ui.mainWindow.unregisterComponent("custom-view");
+  window.roamAlphaAPI.ui.callout.addType({ type: "recipe" });
+  window.roamAlphaAPI.ui.callout.removeType({ type: "recipe" });
+
+  await window.roamAlphaAPI.ui.rightSidebar.addWindow({
+    window: { type: "outline", "block-uid": "abc123xyz" },
+  });
+  const sidebarWindows = window.roamAlphaAPI.ui.rightSidebar.getWindows();
+  await window.roamAlphaAPI.depot.reloadDeveloperExtensions();
+  const base64File = await window.roamAlphaAPI.file.get({
+    url: "https://example.com/file",
+    format: "base64",
+  });
+  const isAdmin = window.roamAlphaAPI.user.isAdmin();
+  window.roamAlphaAPI.ai.addTool({
+    name: "word-count",
+    description: "Counts words in a block.",
+    scope: "read",
+    inputSchema: { type: "object" },
+    handler: ({ uid }, context) => ({
+      uid: String(uid),
+      user: context.tokenUserUid || null,
+    }),
+  });
+  window.roamAlphaAPI.ai.removeTool({ name: "word-count" });
+
+  const canSet = extensionAPI.settings.canSet;
+  await extensionAPI.settings.set("enabled", true);
+  await extensionAPI.settings.panel.create({
+    tabTitle: "Example",
+    settings: [
+      {
+        id: "mode",
+        name: "Mode",
+        action: {
+          type: "select",
+          items: ["fast", "thorough"],
+          onChange: (item) => void item,
+        },
+      },
+    ],
+  });
+  extensionAPI.ui.slashCommand.addCommand({
+    label: "Insert greeting",
+    callback: () => "Hello",
+  });
+  extensionAPI.ai.addTool({
+    name: "status",
+    description: "Returns extension status.",
+    handler: () => ({ ok: true }),
+  });
+
+  void apiVersion;
+  void pullResult;
+  void searchResults;
+  void asyncSearchResults;
+  void queryResults;
+  void selectedBlocks;
+  void openView;
+  void sidebarWindows;
+  void base64File;
+  void isAdmin;
+  void canSet;
+};

--- a/tests/types/documented-api.ts
+++ b/tests/types/documented-api.ts
@@ -87,6 +87,15 @@ type RoamQueryUngroupedSortIsConstrained = AssertFalse<
     RoamQueryArgs
   >
 >;
+type RoamQueryAcceptsComputedGroupingWithoutSort = Assert<
+  IsAssignable<{ query: string; groupByPage: boolean }, RoamQueryArgs>
+>;
+type RoamQueryComputedGroupingStillRejectsSort = AssertFalse<
+  IsAssignable<
+    { query: string; groupByPage: boolean; sort: "page-title" },
+    RoamQueryArgs
+  >
+>;
 type SidebarOrderIsRequired = AssertFalse<
   IsAssignable<
     { window: { type: "outline"; "block-uid": string } },
@@ -96,6 +105,23 @@ type SidebarOrderIsRequired = AssertFalse<
 type RenderBlockZoomStartRequiresZoomPath = AssertFalse<
   IsAssignable<
     { uid: string; el: HTMLElement; "zoom-start-after-uid": string },
+    RenderBlockArgs
+  >
+>;
+type RenderBlockAcceptsComputedZoomPathWithoutStartUid = Assert<
+  IsAssignable<
+    { uid: string; el: HTMLElement; "zoom-path?": boolean },
+    RenderBlockArgs
+  >
+>;
+type RenderBlockComputedZoomPathStillRejectsStartUid = AssertFalse<
+  IsAssignable<
+    {
+      uid: string;
+      el: HTMLElement;
+      "zoom-path?": boolean;
+      "zoom-start-after-uid": string;
+    },
     RenderBlockArgs
   >
 >;
@@ -305,8 +331,12 @@ export type DocumentedApiTypeAssertions =
   | RoamQueryModesAreExclusive
   | RoamQueryGroupedSortIsConstrained
   | RoamQueryUngroupedSortIsConstrained
+  | RoamQueryAcceptsComputedGroupingWithoutSort
+  | RoamQueryComputedGroupingStillRejectsSort
   | SidebarOrderIsRequired
   | RenderBlockZoomStartRequiresZoomPath
+  | RenderBlockAcceptsComputedZoomPathWithoutStartUid
+  | RenderBlockComputedZoomPathStillRejectsStartUid
   | AsyncTokenUserCallbackIsRejected
   | PartialRemovePullWatchIsRejected
   | BlockPropsRemainSupported

--- a/tests/types/documented-api.ts
+++ b/tests/types/documented-api.ts
@@ -30,6 +30,18 @@ type DeletePageArgs = Parameters<
   typeof window.roamAlphaAPI.data.page.delete
 >[0];
 type RoamQueryArgs = Parameters<typeof window.roamAlphaAPI.data.roamQuery>[0];
+type SetWindowOrderArgs = Parameters<
+  typeof window.roamAlphaAPI.ui.rightSidebar.setWindowOrder
+>[0];
+type RenderBlockArgs = Parameters<
+  typeof window.roamAlphaAPI.ui.components.renderBlock
+>[0];
+type AsTokenUser = Parameters<
+  Parameters<typeof window.roamAlphaAPI.ai.addTool>[0]["handler"]
+>[1]["asTokenUser"];
+type RemovePullWatchArgs = Parameters<
+  typeof window.roamAlphaAPI.data.removePullWatch
+>;
 type CreateBlockRequiresFields = AssertFalse<
   IsAssignable<Record<string, never>, CreateBlockArgs>
 >;
@@ -62,6 +74,42 @@ type DeletePageRequiresUid = AssertFalse<
 >;
 type RoamQueryModesAreExclusive = AssertFalse<
   IsAssignable<{ uid: string; query: string }, RoamQueryArgs>
+>;
+type RoamQueryGroupedSortIsConstrained = AssertFalse<
+  IsAssignable<
+    { query: string; groupByPage: true; sort: "created-date" },
+    RoamQueryArgs
+  >
+>;
+type RoamQueryUngroupedSortIsConstrained = AssertFalse<
+  IsAssignable<
+    { query: string; groupByPage: false; sort: "page-title" },
+    RoamQueryArgs
+  >
+>;
+type SidebarOrderIsRequired = AssertFalse<
+  IsAssignable<
+    { window: { type: "outline"; "block-uid": string } },
+    SetWindowOrderArgs
+  >
+>;
+type RenderBlockZoomStartRequiresZoomPath = AssertFalse<
+  IsAssignable<
+    { uid: string; el: HTMLElement; "zoom-start-after-uid": string },
+    RenderBlockArgs
+  >
+>;
+type AsyncTokenUserCallbackIsRejected = AssertFalse<
+  IsAssignable<(callback: () => Promise<void>) => Promise<void>, AsTokenUser>
+>;
+type PartialRemovePullWatchIsRejected = AssertFalse<
+  IsAssignable<[pullPattern: string], RemovePullWatchArgs>
+>;
+type BlockPropsRemainSupported = Assert<
+  IsAssignable<
+    { block: { uid: string; props: Record<string, unknown> } },
+    UpdateBlockArgs
+  >
 >;
 type QueryResultIsExact = Assert<
   IsExact<
@@ -103,7 +151,19 @@ export const exerciseDocumentedApis = async ({
     '[:block/uid "abc123xyz"]',
     () => undefined,
   );
-  await window.roamAlphaAPI.data.removePullWatch();
+  const removeAllPullWatchesResult: null =
+    await window.roamAlphaAPI.data.removePullWatch();
+  const removeMatchingPullWatchesResult: true =
+    await window.roamAlphaAPI.data.removePullWatch(
+      "[:block/string]",
+      '[:block/uid "abc123xyz"]',
+    );
+  const removePullWatchCallbackResult: null =
+    await window.roamAlphaAPI.data.removePullWatch(
+      "[:block/string]",
+      '[:block/uid "abc123xyz"]',
+      () => undefined,
+    );
   await window.roamAlphaAPI.data.block.fromMarkdown({
     location: { "parent-uid": "abc123xyz", order: "last" },
     "markdown-string": "- First block",
@@ -228,6 +288,9 @@ export const exerciseDocumentedApis = async ({
   void canSet;
   void optionallyBase64File;
   void optionalFileResult;
+  void removeAllPullWatchesResult;
+  void removeMatchingPullWatchesResult;
+  void removePullWatchCallbackResult;
 };
 
 export type DocumentedApiTypeAssertions =
@@ -240,5 +303,12 @@ export type DocumentedApiTypeAssertions =
   | UpdatePageRequiresUid
   | DeletePageRequiresUid
   | RoamQueryModesAreExclusive
+  | RoamQueryGroupedSortIsConstrained
+  | RoamQueryUngroupedSortIsConstrained
+  | SidebarOrderIsRequired
+  | RenderBlockZoomStartRequiresZoomPath
+  | AsyncTokenUserCallbackIsRejected
+  | PartialRemovePullWatchIsRejected
+  | BlockPropsRemainSupported
   | QueryResultIsExact
   | CustomPullAttributesAreRepresentable;

--- a/tests/types/documented-api.ts
+++ b/tests/types/documented-api.ts
@@ -1,6 +1,81 @@
 import type { OnloadArgs } from "../../src/types";
 import type { FC } from "react";
 
+type Assert<T extends true> = T;
+type AssertFalse<T extends false> = T;
+type IsAssignable<T, U> = T extends U ? true : false;
+type IsExact<T, U> = (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U
+  ? 1
+  : 2
+  ? true
+  : false;
+
+type CreateBlockArgs = Parameters<
+  typeof window.roamAlphaAPI.data.block.create
+>[0];
+type UpdateBlockArgs = Parameters<
+  typeof window.roamAlphaAPI.data.block.update
+>[0];
+type MoveBlockArgs = Parameters<typeof window.roamAlphaAPI.data.block.move>[0];
+type DeleteBlockArgs = Parameters<
+  typeof window.roamAlphaAPI.data.block.delete
+>[0];
+type CreatePageArgs = Parameters<
+  typeof window.roamAlphaAPI.data.page.create
+>[0];
+type UpdatePageArgs = Parameters<
+  typeof window.roamAlphaAPI.data.page.update
+>[0];
+type DeletePageArgs = Parameters<
+  typeof window.roamAlphaAPI.data.page.delete
+>[0];
+type RoamQueryArgs = Parameters<typeof window.roamAlphaAPI.data.roamQuery>[0];
+type CreateBlockRequiresFields = AssertFalse<
+  IsAssignable<Record<string, never>, CreateBlockArgs>
+>;
+type CreateBlockRequiresString = AssertFalse<
+  IsAssignable<
+    {
+      location: { "parent-uid": string; order: number };
+      block: Record<string, never>;
+    },
+    CreateBlockArgs
+  >
+>;
+type UpdateBlockRequiresUid = AssertFalse<
+  IsAssignable<{ block: { string: string } }, UpdateBlockArgs>
+>;
+type MoveBlockRequiresLocation = AssertFalse<
+  IsAssignable<{ block: { uid: string } }, MoveBlockArgs>
+>;
+type DeleteBlockRequiresUid = AssertFalse<
+  IsAssignable<{ block: Record<string, never> }, DeleteBlockArgs>
+>;
+type CreatePageRequiresTitle = AssertFalse<
+  IsAssignable<{ page: Record<string, never> }, CreatePageArgs>
+>;
+type UpdatePageRequiresUid = AssertFalse<
+  IsAssignable<{ page: { title: string } }, UpdatePageArgs>
+>;
+type DeletePageRequiresUid = AssertFalse<
+  IsAssignable<{ page: Record<string, never> }, DeletePageArgs>
+>;
+type RoamQueryModesAreExclusive = AssertFalse<
+  IsAssignable<{ uid: string; query: string }, RoamQueryArgs>
+>;
+type QueryResultIsExact = Assert<
+  IsExact<
+    Awaited<ReturnType<typeof window.roamAlphaAPI.data.roamQuery>>["total"],
+    number
+  >
+>;
+type CustomPullAttributesAreRepresentable = Assert<
+  IsAssignable<
+    { ":custom/attribute": string },
+    ReturnType<typeof window.roamAlphaAPI.data.search>[number]
+  >
+>;
+
 export const exerciseDocumentedApis = async ({
   extensionAPI,
 }: OnloadArgs): Promise<void> => {
@@ -80,9 +155,6 @@ export const exerciseDocumentedApis = async ({
   window.roamAlphaAPI.ui.mainWindow.openComponent("custom-view", "argument");
   window.roamAlphaAPI.ui.mainWindow.closeComponent("custom-view");
   window.roamAlphaAPI.ui.mainWindow.unregisterComponent("custom-view");
-  window.roamAlphaAPI.ui.callout.addType({ type: "recipe" });
-  window.roamAlphaAPI.ui.callout.removeType({ type: "recipe" });
-
   await window.roamAlphaAPI.ui.rightSidebar.addWindow({
     window: { type: "outline", "block-uid": "abc123xyz" },
   });
@@ -92,6 +164,18 @@ export const exerciseDocumentedApis = async ({
     url: "https://example.com/file",
     format: "base64",
   });
+  const optionalFormat = Date.now() % 2 === 0 ? ("base64" as const) : undefined;
+  const optionallyBase64File = await window.roamAlphaAPI.file.get({
+    url: "https://example.com/file",
+    format: optionalFormat,
+  });
+  const optionalFileResult:
+    | File
+    | {
+        base64: string;
+        filename: string;
+        mimetype: string;
+      } = optionallyBase64File;
   const isAdmin = window.roamAlphaAPI.user.isAdmin();
   window.roamAlphaAPI.ai.addTool({
     name: "word-count",
@@ -142,4 +226,19 @@ export const exerciseDocumentedApis = async ({
   void base64File;
   void isAdmin;
   void canSet;
+  void optionallyBase64File;
+  void optionalFileResult;
 };
+
+export type DocumentedApiTypeAssertions =
+  | CreateBlockRequiresFields
+  | CreateBlockRequiresString
+  | UpdateBlockRequiresUid
+  | MoveBlockRequiresLocation
+  | DeleteBlockRequiresUid
+  | CreatePageRequiresTitle
+  | UpdatePageRequiresUid
+  | DeletePageRequiresUid
+  | RoamQueryModesAreExclusive
+  | QueryResultIsExact
+  | CustomPullAttributesAreRepresentable;

--- a/tsconfig.types-test.json
+++ b/tsconfig.types-test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/types/**/*.ts", "tests/types/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Prepare `roamjs-components` 0.91.0 with Roam Alpha API and Extension API declarations aligned with the current developer documentation. This fixes missing API surfaces and incorrect argument/return types for extension consumers.

- Add search, markdown import, comments, context menus, custom views, callouts, AI tools, and extension settings/slash-command types.
- Require documented block/page write fields while preserving custom `props` on both blocks and pages. Model deletion results on namespaced methods and legacy aliases.
- Correct sidebar input identifiers and response variants, pull-watch call forms, and conditional query/render options, including computed booleans.
- Infer `File`, base64 metadata, or their union from `file.get` options. Allow synchronous `asTokenUser` callbacks to return write promises and document that writes must be issued before any await.
- Add compile-only API contract and regression tests to CI alongside the existing React host unit tests.
- Update the package and lockfile to 0.91.0 and add release notes while retaining the 0.90.0 React host changes.

## Validation

- `npm run test:types`
- `npm run test:unit` — 2 passing tests
- `npm run build`
- `npm run lint`
- `git diff --check`

Live verification on **Roam API 1.1.5** used an authenticated DG Playwright test slot and a temporary developer extension receiving the real ExtensionAPI from Roam. Passed coverage:

- Page/block props and writes, legacy aliases, reorder/move readback, comments, markdown creation, and existing/missing deletion results.
- Sync/async/fast reads, search aliases, grouped/ungrouped queries, and pull-watch callbacks/removal.
- Sidebar window variants and state operations, filter roundtrips, page-graph callbacks, custom main-window React views, and block rendering/unmounting.
- Global and extension command-palette/slash UI invocation, slash insertion/context, all six context-menu registration/removal APIs, and block/page context-menu UI callbacks.
- Extension settings JSON storage, invalid-key rejection, switch/input/select/button callbacks and persistence, and a rendered React settings row.
- Async extension load/cleanup/unload, with automatic removal of settings, commands, slash entries, and namespaced AI tools.
- AI tool discovery and direct JS invocation, input-schema rejection before handler execution, and `asTokenUser` preserving a synchronously issued write promise. This did **not** use an AI token.
- Synthetic file upload, File/base64 retrieval variants, and deletion.

Temporary pages, comments, uploaded file, UI registrations and the developer extension were removed. Developer mode was restored to its original setting. Temporary-page and settings-panel screenshots were inspected. The initial smoke pass captured no page errors; later checks used explicit runtime/UI assertions rather than a comprehensive error-log gate.

Observed documentation differences: reorder/sidebar-add resolve to `null` in this build, while their declarations intentionally expose an unused `void` return; a command callback receives an unused `null` argument. No new consumer-facing type defect was demonstrated by this pass.

**Not verified:** authenticated AI token attribution/scope enforcement; semantic-search results (embeddings disabled); admin/read-only and multi-user permission cases; whole-graph/multiselect/drag-drop and every context-menu/rendering variant; persistent reload across browser restarts; other platforms; global undo/redo or removal of all watches. The full repository Playwright integration suite was not run. Committed API examples remain compile-only tests.

## Documentation

Compared against the live [Developer Hub](https://roamresearch.com/#/app/developer-documentation/page/49715b-M2), [Roam Alpha API](https://roamresearch.com/#/app/developer-documentation/page/tIaOPdXCj), and the [roamdocs.fyi mirror](https://roamdocs.fyi/), including the Extension API reference.

